### PR TITLE
fix: Input 컴포넌트에 ref 추가하여 DOM 접근 하도록 수정

### DIFF
--- a/breaking-front/src/components/Input/Input.js
+++ b/breaking-front/src/components/Input/Input.js
@@ -1,11 +1,11 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import * as Style from 'components/Input/Input.styles';
 
-export default function Input({ status = 'default', icon, ...props }) {
+function Input({ status = 'default', icon, ...props }, ref) {
   return (
     <Style.InputContainer>
-      <Style.Input {...props} />
+      <Style.Input ref={ref} {...props} />
       {icon && <Style.Icon>{icon}</Style.Icon>}
     </Style.InputContainer>
   );
@@ -15,3 +15,5 @@ Input.propTypes = {
   status: PropTypes.oneOf(['default', 'error']),
   icon: PropTypes.element,
 };
+
+export default forwardRef(Input);

--- a/breaking-front/src/components/Input/Input.js
+++ b/breaking-front/src/components/Input/Input.js
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react';
 import PropTypes from 'prop-types';
 import * as Style from 'components/Input/Input.styles';
 
-function Input({ status = 'default', icon, ...props }, ref) {
+function Input({ status, icon, ...props }, ref) {
   return (
     <Style.InputContainer>
       <Style.Input ref={ref} {...props} />
@@ -14,6 +14,10 @@ function Input({ status = 'default', icon, ...props }, ref) {
 Input.propTypes = {
   status: PropTypes.oneOf(['default', 'error']),
   icon: PropTypes.element,
+};
+
+Input.defaultProps = {
+  status: 'default',
 };
 
 export default forwardRef(Input);


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #59 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
Input 컴포넌트에 forwardRef를 추가하여 부모 컴포넌트에서 Input 컴포넌트로 접근할 때 오류가 생기지 않도록 하였습니다.
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
