### PR TITLE
feat: Header 컴포넌트에 프로필 토글 추가

### DIFF
--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -21,7 +21,7 @@ export default function Header({ isLogin, loginButtonClick, ...props }) {
   };
 
   const handleToggle = () => {
-    setIsOpenToggle(!isOpenToggle);
+    setIsOpenToggle((prev) => !prev);
   };
 
   const handleSubmit = (event) => {

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -63,19 +63,22 @@ export default function Header({ isLogin, loginButtonClick, ...props }) {
         <Style.ProfileToggle onMouseDown={(event) => event.preventDefault()}>
           {isOpenToggle && (
             <Toggle width="220px" isArrowMark={true}>
-              <Toggle.LabelLink to={PATH.TRANSACTION}>
-                <MoneyIcon />
-                <Toggle.LabelText>10,000 원</Toggle.LabelText>
-                <Toggle.BlueLabelLink>입출금 내역</Toggle.BlueLabelLink>
-              </Toggle.LabelLink>
-              <Toggle.LabelLink to={PATH.MYPAGE}>
-                <MyPageIcon />
-                <Toggle.LabelText>마이페이지</Toggle.LabelText>
-              </Toggle.LabelLink>
-              <Toggle.LabelLink to={PATH.PROFILE_EDIT}>
-                <SettingIcon />
-                <Toggle.LabelText>프로필 수정</Toggle.LabelText>
-              </Toggle.LabelLink>
+              <Toggle.LabelLink
+                path={PATH.TRANSACTION}
+                icon={<MoneyIcon />}
+                label="10,000원"
+                blueLabel="입출금내역"
+              />
+              <Toggle.LabelLink
+                path={PATH.MYPAGE}
+                icon={<MyPageIcon />}
+                label="마이페이지"
+              />
+              <Toggle.LabelLink
+                path={PATH.PROFILE_EDIT}
+                icon={<SettingIcon />}
+                label="프로필 수정"
+              />
               <Line width="200" />
               <Style.Logout>로그아웃</Style.Logout>
             </Toggle>

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -32,7 +32,7 @@ export default function Header({ isLogin, loginButtonClick, ...props }) {
     <Style.HeaderContainer isLogin={isLogin} {...props}>
       <Style.HeaderContent>
         <Style.SearchContent>
-          <Style.LogoContainer>
+          <Style.LogoContainer to={PATH.HOME}>
             <LogoIcon width="100%" height="100%" />
           </Style.LogoContainer>
           <Style.Form onSubmit={handleSubmit}>

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -43,22 +43,23 @@ export default function Header({ isLogin, loginButtonClick, ...props }) {
             />
           </Style.Form>
         </Style.SearchContent>
-        <Style.ProfileContent
-          onClick={handleToggle}
-          onBlur={handleToggle}
-          tabIndex="0"
-        >
-          {isLogin ? (
-            <>
-              <Style.ProfileImage size="small" src="" />
-              <DownArrowIcon />
-            </>
-          ) : (
+        {isLogin ? (
+          <Style.ProfileContent
+            onClick={handleToggle}
+            onBlur={handleToggle}
+            tabIndex="0"
+          >
+            <Style.ProfileImage size="small" src="" />
+            <DownArrowIcon />
+          </Style.ProfileContent>
+        ) : (
+          <Style.ProfileContent>
             <Style.LoginButton round="rounder" onClick={loginButtonClick}>
               로그인
             </Style.LoginButton>
-          )}
-        </Style.ProfileContent>
+          </Style.ProfileContent>
+        )}
+
         <Style.ProfileToggle onMouseDown={(event) => event.preventDefault()}>
           {isOpenToggle && (
             <Toggle width="220px" isArrowMark={true}>

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -1,16 +1,27 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import Input from 'components/Input/Input';
+import Line from 'components/Line/Line';
+import Toggle from 'components/Toggle/Toggle';
+import { PATH } from 'constants/path';
 import * as Style from 'components/Header/Header.styles';
 import { ReactComponent as LogoIcon } from 'assets/svg/small-logo.svg';
 import { ReactComponent as SearchIcon } from 'assets/svg/search.svg';
 import { ReactComponent as DownArrowIcon } from 'assets/svg/down-arrow.svg';
-import UserImage from 'components/UserImage/UserImage';
+import { ReactComponent as MoneyIcon } from 'assets/svg/money.svg';
+import { ReactComponent as SettingIcon } from 'assets/svg/setting.svg';
+import { ReactComponent as MyPageIcon } from 'assets/svg/mypage.svg';
 
 export default function Header({ isLogin, loginButtonClick, ...props }) {
   const [searchText, setSearchText] = useState('');
+  const [isOpenToggle, setIsOpenToggle] = useState(false);
 
   const onChange = (event) => {
     setSearchText(event.target.value);
+  };
+
+  const handleToggle = () => {
+    setIsOpenToggle(!isOpenToggle);
   };
 
   const handleSubmit = (event) => {
@@ -25,27 +36,50 @@ export default function Header({ isLogin, loginButtonClick, ...props }) {
             <LogoIcon width="100%" height="100%" />
           </Style.LogoContainer>
           <Style.Form onSubmit={handleSubmit}>
-            <Style.SearchInput
+            <Input
               icon={<SearchIcon />}
               onChange={onChange}
               value={searchText}
             />
           </Style.Form>
         </Style.SearchContent>
-        <Style.UserContent>
+        <Style.ProfileContent
+          onClick={handleToggle}
+          onBlur={handleToggle}
+          tabIndex="0"
+        >
           {isLogin ? (
             <>
-              <UserImage size="small" style={{ marginRight: '10px' }} />
-              <Style.UserDetailToggle>
-                <DownArrowIcon />
-              </Style.UserDetailToggle>
+              <Style.ProfileImage size="small" src="" />
+              <DownArrowIcon />
             </>
           ) : (
             <Style.LoginButton round="rounder" onClick={loginButtonClick}>
               로그인
             </Style.LoginButton>
           )}
-        </Style.UserContent>
+        </Style.ProfileContent>
+        <Style.ProfileToggle>
+          {isOpenToggle && (
+            <Toggle width="220px" isArrowMark={true}>
+              <Toggle.LabelLink to={PATH.TRANSACTION}>
+                <MoneyIcon />
+                <Toggle.LabelText>10,000 원</Toggle.LabelText>
+                <Toggle.BlueLabelLink>입출금 내역</Toggle.BlueLabelLink>
+              </Toggle.LabelLink>
+              <Toggle.LabelLink to={PATH.MYPAGE}>
+                <MyPageIcon />
+                <Toggle.LabelText>마이페이지</Toggle.LabelText>
+              </Toggle.LabelLink>
+              <Toggle.LabelLink to={PATH.PROFILE_EDIT}>
+                <SettingIcon />
+                <Toggle.LabelText>프로필 수정</Toggle.LabelText>
+              </Toggle.LabelLink>
+              <Line width="200" />
+              <Style.Logout>로그아웃</Style.Logout>
+            </Toggle>
+          )}
+        </Style.ProfileToggle>
       </Style.HeaderContent>
     </Style.HeaderContainer>
   );

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -59,7 +59,7 @@ export default function Header({ isLogin, loginButtonClick, ...props }) {
             </Style.LoginButton>
           )}
         </Style.ProfileContent>
-        <Style.ProfileToggle>
+        <Style.ProfileToggle onMouseDown={(event) => event.preventDefault()}>
           {isOpenToggle && (
             <Toggle width="220px" isArrowMark={true}>
               <Toggle.LabelLink to={PATH.TRANSACTION}>

--- a/breaking-front/src/components/Header/Header.styles.js
+++ b/breaking-front/src/components/Header/Header.styles.js
@@ -1,5 +1,5 @@
 import Button from 'components/Button/Button';
-import Input from 'components/Input/Input';
+import UserImage from 'components/UserImage/UserImage';
 import styled from 'styled-components';
 
 export const HeaderContainer = styled.header`
@@ -12,6 +12,7 @@ export const HeaderContainer = styled.header`
 
 export const HeaderContent = styled.div`
   display: flex;
+  position: relative;
   justify-content: space-between;
   max-width: 950px;
   height: 100%;
@@ -23,9 +24,10 @@ export const SearchContent = styled.div`
   display: flex;
   align-items: center;
 `;
-export const UserContent = styled.div`
+export const ProfileContent = styled.div`
   display: flex;
   align-items: center;
+  cursor: pointer;
 `;
 
 // 추후에 Link 태그로 바꾸고 클릭 시 홈으로 이동하도록 수정
@@ -38,11 +40,22 @@ export const Form = styled.form`
   width: 280px;
 `;
 
-export const SearchInput = styled(Input)``;
-
 export const LoginButton = styled(Button)`
   padding: 10px 30px;
 `;
 
-// 추후 토글 컴포넌트 구현시 수정
-export const UserDetailToggle = styled.div``;
+export const ProfileImage = styled(UserImage)`
+  margin-right: 10px;
+`;
+
+export const ProfileToggle = styled.div`
+  position: absolute;
+  top: 80px;
+  right: -20px;
+`;
+
+export const Logout = styled.p`
+  text-align: center;
+  margin: 10px;
+  cursor: pointer;
+`;

--- a/breaking-front/src/components/Header/Header.styles.js
+++ b/breaking-front/src/components/Header/Header.styles.js
@@ -1,5 +1,6 @@
 import Button from 'components/Button/Button';
 import UserImage from 'components/UserImage/UserImage';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 export const HeaderContainer = styled.header`
@@ -30,8 +31,7 @@ export const ProfileContent = styled.div`
   cursor: pointer;
 `;
 
-// 추후에 Link 태그로 바꾸고 클릭 시 홈으로 이동하도록 수정
-export const LogoContainer = styled.div`
+export const LogoContainer = styled(Link)`
   width: 55px;
   margin-right: 70px;
 `;

--- a/breaking-front/src/components/Toggle/Toggle.js
+++ b/breaking-front/src/components/Toggle/Toggle.js
@@ -11,9 +11,17 @@ export default function Toggle({ isArrowMark, width, children }) {
   );
 }
 
-Toggle.LabelLink = Style.LabelLink;
-Toggle.BlueLabelLink = Style.BlueLabelLink;
-Toggle.LabelText = Style.LabelText;
+function LabelLink({ path, label, blueLabel, icon }) {
+  return (
+    <Style.LabelLink to={path}>
+      {icon}
+      <Style.LabelText>{label}</Style.LabelText>
+      {blueLabel && <Style.BlueLabel>{blueLabel}</Style.BlueLabel>}
+    </Style.LabelLink>
+  );
+}
+
+Toggle.LabelLink = LabelLink;
 
 Toggle.propTypes = {
   isArrowMark: PropTypes.bool,
@@ -24,4 +32,11 @@ Toggle.propTypes = {
 Toggle.defaultProps = {
   isArrowMark: false,
   width: '120px',
+};
+
+LabelLink.propTypes = {
+  path: PropTypes.string,
+  icon: PropTypes.node,
+  label: PropTypes.string,
+  blueLabel: PropTypes.string,
 };

--- a/breaking-front/src/components/Toggle/Toggle.stories.js
+++ b/breaking-front/src/components/Toggle/Toggle.stories.js
@@ -5,14 +5,13 @@ import { ReactComponent as SettingIcon } from 'assets/svg/setting.svg';
 import { ReactComponent as MyPageIcon } from 'assets/svg/mypage.svg';
 import Line from 'components/Line/Line';
 import { PATH } from 'constants/path';
+import styled from 'styled-components';
 
 export default {
   title: 'components/Toggle',
   component: Toggle,
   subComponents: {
     'Toggle.LabelLink': Toggle.LabelLink,
-    'Toggle.BlueLabelLink': Toggle.BlueLabelLink,
-    'Toggle.LabelText': Toggle.LabelText,
   },
 };
 
@@ -27,27 +26,36 @@ function Template(args) {
   );
 }
 
+const Logout = styled.p`
+  text-align: center;
+  margin: 10px;
+  cursor: pointer;
+`;
+
 export const ProfileToggle = Template.bind({});
 ProfileToggle.args = {
   isArrowMark: true,
   width: '220px',
   children: (
     <>
-      <Toggle.LabelLink to={PATH.TRANSACTION}>
-        <MoneyIcon />
-        <Toggle.LabelText>10,000 원</Toggle.LabelText>
-        <Toggle.BlueLabelLink>입출금 내역</Toggle.BlueLabelLink>
-      </Toggle.LabelLink>
-      <Toggle.LabelLink to={PATH.MYPAGE}>
-        <MyPageIcon />
-        <Toggle.LabelText>마이페이지</Toggle.LabelText>
-      </Toggle.LabelLink>
-      <Toggle.LabelLink to={PATH.PROFILE_EDIT}>
-        <SettingIcon />
-        <Toggle.LabelText>프로필 수정</Toggle.LabelText>
-      </Toggle.LabelLink>
+      <Toggle.LabelLink
+        path={PATH.TRANSACTION}
+        icon={<MoneyIcon />}
+        label="10,000원"
+        blueLabel="입출금내역"
+      />
+      <Toggle.LabelLink
+        path={PATH.MYPAGE}
+        icon={<MyPageIcon />}
+        label="마이페이지"
+      />
+      <Toggle.LabelLink
+        path={PATH.PROFILE_EDIT}
+        icon={<SettingIcon />}
+        label="프로필 수정"
+      />
       <Line width="200" />
-      <p style={{ textAlign: 'center' }}>로그아웃</p>
+      <Logout>로그아웃</Logout>
     </>
   ),
 };
@@ -56,18 +64,17 @@ export const NarrowToggle = Template.bind({});
 NarrowToggle.args = {
   children: (
     <>
-      <Toggle.LabelLink to={PATH.MYPAGE}>
-        <MoneyIcon />
-        <Toggle.LabelText>수정</Toggle.LabelText>
-      </Toggle.LabelLink>
-      <Toggle.LabelLink to={PATH.MYPAGE}>
-        <MoneyIcon />
-        <Toggle.LabelText>삭제</Toggle.LabelText>
-      </Toggle.LabelLink>
-      <Toggle.LabelLink to={PATH.MYPAGE}>
-        <MoneyIcon />
-        <Toggle.LabelText>공유</Toggle.LabelText>
-      </Toggle.LabelLink>
+      <Toggle.LabelLink
+        path={PATH.TRANSACTION}
+        icon={<MoneyIcon />}
+        label="수정"
+      />
+      <Toggle.LabelLink path={PATH.MYPAGE} icon={<MyPageIcon />} label="삭제" />
+      <Toggle.LabelLink
+        path={PATH.PROFILE_EDIT}
+        icon={<SettingIcon />}
+        label="공유"
+      />
     </>
   ),
 };

--- a/breaking-front/src/components/Toggle/Toggle.styles.js
+++ b/breaking-front/src/components/Toggle/Toggle.styles.js
@@ -28,6 +28,7 @@ export const Toggle = styled.div`
   padding: 15px 10px 5px;
   border: 1px solid ${({ theme }) => theme.black};
   border-radius: 10px;
+  background-color: ${({ theme }) => theme.white};
 `;
 
 export const LabelLink = styled(Link)`

--- a/breaking-front/src/components/Toggle/Toggle.styles.js
+++ b/breaking-front/src/components/Toggle/Toggle.styles.js
@@ -42,7 +42,7 @@ export const LabelText = styled.label`
   cursor: pointer;
 `;
 
-export const BlueLabelLink = styled.span`
+export const BlueLabel = styled.span`
   position: absolute;
   right: 20px;
   font-size: 12px;


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #63 

## 예상 리뷰 시간
4-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
Header 컴포넌트에 프로필 토글 기능을 추가하였습니다.  

프로필 이미지 또는 토글 버튼 클릭 시 나타나고, 아무 곳이나 다시 클릭하면 사라집니다.

https://www.chromatic.com/build?appId=62ba6453935e74836cffb2d4&number=11

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/23312485/177700892-73b249b0-6bba-47ea-a52a-d83d686f71f6.png)
