### PR TITLE
feat: 백엔드와 로그인 테스트 작업

### DIFF
--- a/breaking-front/src/App.js
+++ b/breaking-front/src/App.js
@@ -4,13 +4,14 @@ import GlobalStyle from 'styles/GlobalStyle';
 import theme from 'styles/theme';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import SocialLogin from 'pages/SocialLogin/SocialLogin';
-import KakaoRedirect from 'pages/SocialLogin/KakaoRedirect';
+import KakaoRedirect from 'pages/SocialLogin/Redirect/KakaoRedirect';
 import SignUp from 'pages/SignUp/SignUp';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { ReactQueryDevtools } from 'react-query/devtools';
 import { PATH } from 'constants/path';
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import Layout from 'components/Layout/Layout';
+import GoogleRedirect from 'pages/SocialLogin/Redirect/GoogleRedirect';
 
 function App() {
   const queryClient = new QueryClient();
@@ -26,6 +27,10 @@ function App() {
                 <Route
                   path={PATH.KAKAO_LOGIN}
                   element={<KakaoRedirect />}
+                ></Route>
+                <Route
+                  path={PATH.GOOGLE_LOGIN}
+                  element={<GoogleRedirect />}
                 ></Route>
                 <Route path={PATH.SIGNUP} element={<SignUp />} />
               </Routes>

--- a/breaking-front/src/api/api.js
+++ b/breaking-front/src/api/api.js
@@ -3,7 +3,7 @@ const { DEVELOPMENT_BASE_URL, PRODUCTION_BASE_URL } = require('constants/path');
 
 const api = axios.create({
   baseURL:
-    process.env.DEPLOY_ENV !== 'production'
+    process.env.NODE_ENV !== 'production'
       ? DEVELOPMENT_BASE_URL
       : PRODUCTION_BASE_URL,
   headers: {

--- a/breaking-front/src/api/login.js
+++ b/breaking-front/src/api/login.js
@@ -1,17 +1,17 @@
 import axios from 'axios';
-import { KAKAO_PATH, PATH } from 'constants/path';
+import { PATH } from 'constants/path';
 import api from 'api/api';
 
 export const postAccessCode = (data) => {
   const headers = {
     'Content-Type': 'application/x-www-form-urlencoded',
   };
-  const queryStringBody = Object.keys(data)
-    .map((k) => encodeURIComponent(k) + '=' + encodeURI(data[k]))
+  const queryStringBody = Object.keys(data.data)
+    .map((k) => encodeURIComponent(k) + '=' + encodeURI(data.data[k]))
     .join('&');
   return axios({
     method: 'post',
-    url: KAKAO_PATH.OAUTH_TOKEN,
+    url: data.url,
     headers: headers,
     data: queryStringBody,
   });

--- a/breaking-front/src/constants/path.js
+++ b/breaking-front/src/constants/path.js
@@ -2,6 +2,7 @@ export const PATH = {
   HOME: '/',
   LOGIN: '/login',
   KAKAO_LOGIN: 'login/kakao',
+  GOOGLE_LOGIN: 'login/google',
   SIGNUP: '/signup',
   OAUTH2_SIGNUP: '/oauth2/sign-up',
   OAUTH2_SIGNUP_VALIDATE_PHONE_NUMBER: '/oauth2/sign-up/validate-phone-number',
@@ -18,6 +19,11 @@ export const PATH = {
 export const KAKAO_PATH = {
   REDIRECT_URL: 'http://localhost:3000/login/kakao',
   OAUTH_TOKEN: 'https://kauth.kakao.com/oauth/token',
+};
+
+export const GOOGLE_PATH = {
+  REDIRECT_URL: 'http://localhost:3000/login/google',
+  OAUTH_TOKEN: 'https://oauth2.googleapis.com/token',
 };
 
 export const DEVELOPMENT_BASE_URL = 'http://localhost:3000/';

--- a/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
+++ b/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
@@ -41,7 +41,7 @@ const GoogleRedirect = () => {
       data: {
         grant_type: 'authorization_code',
         client_id: process.env.REACT_APP_GOOGLE_CLIENT_KEY,
-        client_secret: process.env.REACT_APP_GOOGLE_CLIENT_SECRIT,
+        client_secret: process.env.REACT_APP_GOOGLE_CLIENT_SECRET,
         redirect_uri: GOOGLE_PATH.REDIRECT_URL,
         code: accessCode,
       },

--- a/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
+++ b/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
@@ -1,0 +1,53 @@
+import { postAccessCode, postSignInWithGoogle } from 'api/login';
+import { GOOGLE_PATH, PATH } from 'constants/path';
+import React, { useEffect } from 'react';
+import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+
+const GoogleRedirect = () => {
+  const navigate = useNavigate();
+
+  const accessCode = new URL(window.location.href).searchParams.get('code');
+
+  const SignUpGoogle = useMutation(postSignInWithGoogle, {
+    onSuccess: (res) => {
+      console.log(res);
+      const jwtToken = res.headers.authorization;
+      if (jwtToken) {
+        localStorage.setItem('access_token', res.headers.authorization);
+        navigate(PATH.HOME);
+      } else {
+        navigate(PATH.SIGNUP, { state: res.data });
+      }
+    },
+  });
+
+  const GetGoogleToken = useMutation(postAccessCode, {
+    onSuccess: (res) => {
+      console.log(res.data);
+      SignUpGoogle.mutate({
+        accessToken: res.data.access_token,
+        idToken: res.data.id_token,
+      });
+    },
+    onError: () => {
+      //에러 페이지 이동
+    },
+  });
+
+  useEffect(() => {
+    GetGoogleToken.mutate({
+      url: GOOGLE_PATH.OAUTH_TOKEN,
+      data: {
+        grant_type: 'authorization_code',
+        client_id: process.env.REACT_APP_GOOGLE_CLIENT_KEY,
+        client_secret: process.env.REACT_APP_GOOGLE_CLIENT_SECRIT,
+        redirect_uri: GOOGLE_PATH.REDIRECT_URL,
+        code: accessCode,
+      },
+    });
+  }, []);
+
+  return <></>;
+};
+export default GoogleRedirect;

--- a/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
+++ b/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
@@ -9,7 +9,7 @@ const GoogleRedirect = () => {
 
   const accessCode = new URL(window.location.href).searchParams.get('code');
 
-  const SignUpGoogle = useMutation(postSignInWithGoogle, {
+  const SignInGoogle = useMutation(postSignInWithGoogle, {
     onSuccess: (res) => {
       console.log(res);
       const jwtToken = res.headers.authorization;
@@ -25,7 +25,7 @@ const GoogleRedirect = () => {
   const GetGoogleToken = useMutation(postAccessCode, {
     onSuccess: (res) => {
       console.log(res.data);
-      SignUpGoogle.mutate({
+      SignInGoogle.mutate({
         accessToken: res.data.access_token,
         idToken: res.data.id_token,
       });

--- a/breaking-front/src/pages/SocialLogin/Redirect/KakaoRedirect.js
+++ b/breaking-front/src/pages/SocialLogin/Redirect/KakaoRedirect.js
@@ -1,4 +1,4 @@
-import { postAccessCode } from 'api/login';
+import { postAccessCode, postSignInWithKakao } from 'api/login';
 import { KAKAO_PATH, PATH } from 'constants/path';
 import React, { useEffect } from 'react';
 import { useMutation } from 'react-query';
@@ -6,35 +6,47 @@ import { useNavigate } from 'react-router-dom';
 
 const KakaoRedirect = () => {
   const navigate = useNavigate();
+
   const accessCode = new URL(window.location.href).searchParams.get('code');
-  const getKakaoToken = useMutation(postAccessCode, {
+
+  const SignUpKakao = useMutation(postSignInWithKakao, {
     onSuccess: (res) => {
       console.log(res);
       const jwtToken = res.headers.authorization;
       if (jwtToken) {
-        localStorage.setItem({
-          key: 'access_token',
-          value: res.headers.authorization,
-        });
+        localStorage.setItem('access_token', res.headers.authorization);
         navigate(PATH.HOME);
       } else {
         navigate(PATH.SIGNUP, { state: res.data });
       }
     },
+  });
+
+  const GetKakaoToken = useMutation(postAccessCode, {
+    onSuccess: (res) => {
+      console.log(res);
+      SignUpKakao.mutate({
+        accessToken: res.data.access_token,
+      });
+    },
     onError: () => {
       //에러 페이지 이동
     },
   });
+
   useEffect(() => {
-    getKakaoToken.mutate({
-      grant_type: 'authorization_code',
-      client_id: process.env.REACT_APP_REST_API_KEY,
-      redirect_uri: KAKAO_PATH.REDIRECT_URL,
-      code: accessCode,
+    GetKakaoToken.mutate({
+      url: KAKAO_PATH.OAUTH_TOKEN,
+      data: {
+        grant_type: 'authorization_code',
+        client_id: process.env.REACT_APP_REST_API_KEY,
+        redirect_uri: KAKAO_PATH.REDIRECT_URL,
+        code: accessCode,
+      },
     });
   }, []);
 
-  return <div />;
+  return <></>;
 };
 
 export default KakaoRedirect;

--- a/breaking-front/src/pages/SocialLogin/Redirect/KakaoRedirect.js
+++ b/breaking-front/src/pages/SocialLogin/Redirect/KakaoRedirect.js
@@ -9,7 +9,7 @@ const KakaoRedirect = () => {
 
   const accessCode = new URL(window.location.href).searchParams.get('code');
 
-  const SignUpKakao = useMutation(postSignInWithKakao, {
+  const SignInKakao = useMutation(postSignInWithKakao, {
     onSuccess: (res) => {
       console.log(res);
       const jwtToken = res.headers.authorization;
@@ -25,7 +25,7 @@ const KakaoRedirect = () => {
   const GetKakaoToken = useMutation(postAccessCode, {
     onSuccess: (res) => {
       console.log(res);
-      SignUpKakao.mutate({
+      SignInKakao.mutate({
         accessToken: res.data.access_token,
       });
     },

--- a/breaking-front/src/pages/SocialLogin/SocialLogin.js
+++ b/breaking-front/src/pages/SocialLogin/SocialLogin.js
@@ -1,43 +1,26 @@
-import { KAKAO_PATH, PATH } from 'constants/path';
+import { GOOGLE_PATH, KAKAO_PATH } from 'constants/path';
 import React from 'react';
 import { useGoogleLogin } from '@react-oauth/google';
 import SocialLoginButton from 'components/SocialLoginButton/SocialLoginButton';
 import * as Style from 'pages/SocialLogin/SocialLogin.style';
 import Line from 'components/Line/Line';
 import MobileDownloadButton from 'components/MobileDownloadButton/MobileDownloadButton';
-import { useMutation } from 'react-query';
-import { postSignInWithGoogle } from 'api/login';
-import { useNavigate } from 'react-router-dom';
 
 const SocialLogin = () => {
-  const navigate = useNavigate();
-  const SignInWithGoogle = useMutation(postSignInWithGoogle, {
-    onSuccess: (res) => {
-      console.log(res);
-      const jwtToken = res.headers.authorization;
-      if (jwtToken) {
-        localStorage.setItem('access_token', res.headers.authorization);
-        navigate(PATH.HOME);
-        //로그인 완료처리
-      } else {
-        navigate(PATH.SIGNUP, { state: res.data });
-      }
-    },
-    onError: () => {},
-  });
   const googleLoginClick = useGoogleLogin({
-    onSuccess: (res) => {
-      SignInWithGoogle.mutate(res.access_token);
-    },
+    flow: 'auth-code',
+    redirect_uri: GOOGLE_PATH.REDIRECT_URL,
+    ux_mode: 'redirect',
     onError: () => {},
   });
+
   const { Kakao } = window;
+
   if (!Kakao.isInitialized()) {
     Kakao.init(process.env.REACT_APP_KAKAO_JAVASCRIPT_KEY);
   }
+
   const kakaoLoginClick = () => {
-    // Kakao.Auth.login();
-    // 관리자 권한이 등록이 되면 팝업 방식으로 전환
     Kakao.Auth.authorize({
       redirectUri: KAKAO_PATH.REDIRECT_URL,
     });


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #70 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
기존에 팝업 모드를 하기로 했었는데 백엔드에서 진행하는 걸로 하면 리다이렉트 하는 방법을 사용해야하서 소셜로그인 전부 리다이렉트 버젼으로 바꾸었습니다

진행방식은 다음과 같습니다
1. 소셜 로그인을 하여서 서버에 인가코드를 요청한다
2. 인가코드를 다시 서버에 요청해서 토큰을 받아온다
3. 토큰 값을 백엔드로 넘겨준다
4. 백엔드에서 응답을주면 홈화면이나 회원가입 페이지로 이동한다


## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
지금은 로그인시에 백엔드에서 받아온 모든 데이터를 회원가입 페이지로 넘겼습니다.
