### PR TITLE
fix: ProfileImage 버그 수정 및 xlarge 크기 변경

### DIFF
--- a/breaking-front/src/components/ProfileImage/ProfileImage.styles.js
+++ b/breaking-front/src/components/ProfileImage/ProfileImage.styles.js
@@ -15,24 +15,25 @@ const sizeCss = {
     height: 100px;
   `,
   xlarge: css`
-    width: 250px;
-    height: 250px;
+    width: 200px;
+    height: 200px;
   `,
 };
 
-export const ProfileImageContainer = styled.div`
-  cursor: pointer;
-`;
+export const ProfileImageContainer = styled.div``;
 
 export const ProfileImage = styled.img`
   ${({ size }) => sizeCss[size]};
   border-radius: 50%;
+  object-fit: cover;
+  cursor: pointer;
 `;
 
 export const DefaultImage = styled.img.attrs({
   src: `${defaultImage}`,
 })`
   ${({ size }) => sizeCss[size]};
-  background-color: ${({ theme }) => theme.gray[300]};
+  background-color: ${({ theme }) => theme.gray[200]};
   border-radius: 50%;
+  cursor: pointer;
 `;

--- a/breaking-front/src/components/ProfileImage/ProfileImage.styles.js
+++ b/breaking-front/src/components/ProfileImage/ProfileImage.styles.js
@@ -33,7 +33,6 @@ export const DefaultImage = styled.img.attrs({
   src: `${defaultImage}`,
 })`
   ${({ size }) => sizeCss[size]};
-  background-color: ${({ theme }) => theme.gray[200]};
   border-radius: 50%;
   cursor: pointer;
 `;


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #82

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- ProFileImage 컴포넌트에서 이미지가 뭉개져 보이는 현상을 `object-fit: cover;`를 추가하여 해결했습니다.
- 마우스 포인터가 적용되는 범위가 이미지를 감싸는 사각형 div로 적용이 되는 문제가 있어서 동그란 이미지 안에서만 마우스 포인터가 바뀌는 것으로 수정했습니다.
- DefaultImage에서 불필요한 background-color를 제거했습니다.
- xlarge의 크기를 250x250 에서 200x200으로 바꾸었습니다.