### PR TITLE
chore: axios 요청 시 로그인한 유저는 header에 JWTtoken을 넣어 전송하도록 설정

### DIFF
--- a/breaking-front/src/api/api.js
+++ b/breaking-front/src/api/api.js
@@ -11,4 +11,22 @@ const api = axios.create({
   },
 });
 
+api.interceptors.request.use(
+  (config) => {
+    const accessToken = localStorage.getItem('access_token');
+    if (!accessToken) return config;
+
+    config.headers = {
+      'Content-type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    };
+
+    return config;
+  },
+
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
 export default api;


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #98 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
axios 요청 시 로그인한 유저는 header에 JWTtoken을 넣어 전송하도록 설정했습니다.
로컬스토리지에 토큰이 있는 상황에서 재로그인시에 오류가 발생할 수 있습니다. 테스트 시 로컬스토리지에 있는 토큰을 수동으로 삭제하고 테스트하기 바랍니다.