### PR TITLE
feat: 프로필 수정 페이지 로직 구현

### DIFF
--- a/breaking-front/package-lock.json
+++ b/breaking-front/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^18.2.0",
         "react-datepicker": "^4.8.0",
         "react-dom": "^18.2.0",
+        "react-loading": "^2.0.3",
         "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0",
         "react-scripts": "5.0.1",
@@ -27147,6 +27148,15 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-loading": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-loading/-/react-loading-2.0.3.tgz",
+      "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A==",
+      "peerDependencies": {
+        "prop-types": "^15.6.0",
+        "react": ">=0.14.0"
+      }
+    },
     "node_modules/react-merge-refs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz",
@@ -52956,6 +52966,12 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-loading": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-loading/-/react-loading-2.0.3.tgz",
+      "integrity": "sha512-Vdqy79zq+bpeWJqC+xjltUjuGApyoItPgL0vgVfcJHhqwU7bAMKzysfGW/ADu6i0z0JiOCRJjo+IkFNkRNbA3A==",
+      "requires": {}
     },
     "react-merge-refs": {
       "version": "1.1.0",

--- a/breaking-front/package.json
+++ b/breaking-front/package.json
@@ -9,6 +9,7 @@
     "react": "^18.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "^18.2.0",
+    "react-loading": "^2.0.3",
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",

--- a/breaking-front/src/App.js
+++ b/breaking-front/src/App.js
@@ -13,6 +13,7 @@ import { GoogleOAuthProvider } from '@react-oauth/google';
 import Layout from 'components/Layout/Layout';
 import GoogleRedirect from 'pages/SocialLogin/Redirect/GoogleRedirect';
 import Profile from 'pages/Profile/Profile';
+import ProfileEdit from 'pages/ProfileEdit/ProfileEdit';
 
 function App() {
   const queryClient = new QueryClient();
@@ -35,6 +36,10 @@ function App() {
                 ></Route>
                 <Route path={PAGE_PATH.SIGNUP} element={<SignUp />} />
                 <Route path={PAGE_PATH.PROFILE} element={<Profile />} />
+                <Route
+                  path={PAGE_PATH.PROFILE_EDIT}
+                  element={<ProfileEdit />}
+                />
               </Routes>
             </Layout>
           </BrowserRouter>

--- a/breaking-front/src/api/profile.js
+++ b/breaking-front/src/api/profile.js
@@ -1,0 +1,25 @@
+import { API_PATH } from 'constants/path';
+import api from 'api/api';
+
+export const postProfileData = () => {
+  return api({
+    method: 'post',
+    url: API_PATH.OAUTH2_VALIDATE_JWT,
+  });
+};
+
+export const putProfileEdit = (userData) => {
+  return api({
+    method: 'put',
+    url: API_PATH.PROFILE_EDIT,
+    'Content-Type': 'multipart/form-data',
+    data: userData,
+  });
+};
+
+export const getProfileDetailData = () => {
+  return api({
+    method: 'get',
+    url: API_PATH.PROFILE_DETAIL_DATA,
+  });
+};

--- a/breaking-front/src/api/profileEdit.js
+++ b/breaking-front/src/api/profileEdit.js
@@ -1,13 +1,6 @@
 import { API_PATH } from 'constants/path';
 import api from 'api/api';
 
-export const postProfileData = () => {
-  return api({
-    method: 'post',
-    url: API_PATH.OAUTH2_VALIDATE_JWT,
-  });
-};
-
 export const putProfileEdit = (userData) => {
   return api({
     method: 'put',

--- a/breaking-front/src/components/ProfileImage/ProfileImage.styles.js
+++ b/breaking-front/src/components/ProfileImage/ProfileImage.styles.js
@@ -27,6 +27,7 @@ export const ProfileImage = styled.img`
   border-radius: 50%;
   object-fit: cover;
   cursor: pointer;
+  background-color: ${({ theme }) => theme.gray[200]};
 `;
 
 export const DefaultImage = styled.img.attrs({
@@ -35,4 +36,5 @@ export const DefaultImage = styled.img.attrs({
   ${({ size }) => sizeCss[size]};
   border-radius: 50%;
   cursor: pointer;
+  background-color: ${({ theme }) => theme.gray[200]};
 `;

--- a/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.js
+++ b/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.js
@@ -4,14 +4,14 @@ import Button from 'components/Button/Button';
 import ProfileSettingInput from 'components/ProfileSettingForm/ProfileSettingInput';
 import ProfileImage from 'components/ProfileImage/ProfileImage';
 import useIsValidProfile from 'hooks/queries/useIsValidProfile';
-import useInputs from 'hooks/useInputs';
+import { useTheme } from 'styled-components';
+import { PRODUCTION_BASE_URL } from 'constants/path';
 import MESSAGE from 'constants/message';
+import useInputs from 'hooks/useInputs';
 import fileToBase64 from 'utils/fileToBase64';
 import urlToFile from 'utils/urlToFile';
 import { ReactComponent as XMark } from 'assets/svg/x-mark.svg';
 import * as Style from 'components/ProfileSettingForm/ProfileSettingForm.styles';
-import { useTheme } from 'styled-components';
-import { PRODUCTION_BASE_URL } from 'constants/path';
 
 export default function ProfileSettingForm({
   pageType,
@@ -23,11 +23,19 @@ export default function ProfileSettingForm({
   const imageRef = useRef();
   const theme = useTheme();
   const [
-    { profileImgURL, realName, nickname, phoneNumber, statusMsg, email, role },
+    {
+      profileImgURL: profileImg,
+      realName,
+      nickname,
+      phoneNumber,
+      statusMsg,
+      email,
+      role,
+    },
     handleChange,
     setForm,
   ] = useInputs(userDefaultData);
-  const [imageSrc, setImageSrc] = useState(profileImgURL);
+  const [imageSrc, setImageSrc] = useState(userDefaultData.profileImgURL);
   const [realNameErrorMessage, setRealNameErrorMessage] = useState('');
   const [nicknameErrorMessage, setNicknameErrorMessage] = useState('');
   const [phoneNumberErrorMessage, setPhoneNumberErrorMessage] = useState('');
@@ -99,35 +107,48 @@ export default function ProfileSettingForm({
       role,
     };
 
-    if (pageType === 'profileEdit') {
-      if (profileImgURL !== '') {
-        if (profileImgURL === userDefaultData.profileImgURL) {
-          const imageFile = await urlToFile(profileImgURL);
+    // if (pageType === 'profileEdit') {
+    //   if (profileImg !== '') {
+    //     if (profileImg === userDefaultData.profileImgURL) {
+    //       const imageFile = await urlToFile(profileImg);
+    //       formData.append('profileImg', imageFile);
+    //     } else formData.append('profileImg', profileImg);
+    //   } else formData.append('profileImg', '');
 
-          formData.append('profileImg', imageFile);
-        } else formData.append('profileImg', profileImgURL);
-      }
-
+    //   formData.append('updateRequest', JSON.stringify(userData));
+    // } else if (pageType === 'signUp') {
+    //   userData.username = username;
+    //   formData.append('profileImg', profileImg);
+    //   formData.append('signUpRequest', JSON.stringify(userData));
+    // }
+    if (
+      pageType === 'profileEdit' &&
+      profileImg === userDefaultData.profileImgURL
+    ) {
+      const imageFile = await urlToFile(profileImg);
+      formData.append('profileImg', imageFile);
+      formData.append('updateRequest', JSON.stringify(userData));
+    } else if (pageType === 'profileEdit') {
+      formData.append('profileImg', profileImg);
       formData.append('updateRequest', JSON.stringify(userData));
     } else if (pageType === 'signUp') {
       userData.username = username;
-
-      formData.append('profileImg', profileImgURL);
+      formData.append('profileImg', profileImg);
       formData.append('signUpRequest', JSON.stringify(userData));
     }
+    console.log('profileImg: ', profileImg);
+    console.log('userData: ', userData);
 
     mutate(formData);
   };
 
   useEffect(() => {
-    if (pageType === 'profileEdit') {
-      setForm(userDefaultData);
+    setForm(userDefaultData);
 
-      if (userDefaultData.profileImgURL)
-        setImageSrc(
-          PRODUCTION_BASE_URL + 'static' + userDefaultData.profileImgURL
-        );
-    }
+    userDefaultData.profileImgURL &&
+      setImageSrc(
+        PRODUCTION_BASE_URL + 'static' + userDefaultData.profileImgURL
+      );
   }, [userDefaultData, pageType, setForm]);
 
   return (
@@ -153,7 +174,7 @@ export default function ProfileSettingForm({
               />
             )}
 
-            {profileImgURL && (
+            {profileImg && (
               <Style.XMarkIcon>
                 <XMark onClick={imageDeleteClick} />
               </Style.XMarkIcon>

--- a/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.js
+++ b/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.js
@@ -1,14 +1,15 @@
 import React, { useRef, useState } from 'react';
+import PropTypes from 'prop-types';
 import Button from 'components/Button/Button';
 import ProfileSettingInput from 'components/ProfileSettingForm/ProfileSettingInput';
+import ProfileImage from 'components/ProfileImage/ProfileImage';
 import useIsValidProfile from 'hooks/queries/useIsValidProfile';
 import useInputs from 'hooks/useInputs';
 import MESSAGE from 'constants/message';
 import fileToBase64 from 'utils/fileToBase64';
+import urlToFile from 'utils/urlToFile';
 import { ReactComponent as XMark } from 'assets/svg/x-mark.svg';
 import * as Style from 'components/ProfileSettingForm/ProfileSettingForm.styles';
-import ProfileImage from 'components/ProfileImage/ProfileImage';
-import PropTypes from 'prop-types';
 
 export default function ProfileSettingForm({
   username,
@@ -59,7 +60,7 @@ export default function ProfileSettingForm({
 
   const imageDeleteClick = () => {
     setImageSrc('');
-    setForm((form) => ({ ...form, profileImg: '' }));
+    setForm((form) => ({ ...form, profileImgURL: '' }));
   };
 
   const handleKeyDown = (event) => {
@@ -73,7 +74,7 @@ export default function ProfileSettingForm({
     }
   };
 
-  const handleSubmit = (event) => {
+  const handleSubmit = async (event) => {
     event.preventDefault();
 
     if (nicknameErrorMessage)
@@ -95,7 +96,15 @@ export default function ProfileSettingForm({
     };
 
     if (username) userData.username = username;
-    if (profileImgURL !== '') formData.append('profileImg', profileImgURL);
+
+    if (profileImgURL !== '') {
+      //프로필 수정 페이지에서 유저가 프로필 이미지를 변경하지 않은 경우 기존 이미지 파일 전송
+      if (!username && profileImgURL === userDefaultData.profileImgURL) {
+        const imageFile = await urlToFile(profileImgURL);
+        formData.append('profileImg', imageFile);
+      } else formData.append('profileImg', profileImgURL);
+    }
+
     formData.append('signUpRequest', JSON.stringify(userData));
 
     mutate(formData);

--- a/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.styles.js
+++ b/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.styles.js
@@ -1,5 +1,6 @@
-import Button from 'components/Button/Button';
 import styled from 'styled-components';
+import Button from 'components/Button/Button';
+import ReactLoading from 'react-loading';
 
 export const Form = styled.form`
   width: 600px;
@@ -7,13 +8,26 @@ export const Form = styled.form`
 `;
 
 export const ProfileImageContainer = styled.div`
-  position: relative;
   display: flex;
   height: 300px;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   text-align: center;
+`;
+
+export const ProfileImage = styled.div`
+  position: relative;
+  width: 200px;
+  height: 200px;
+`;
+
+export const Loading = styled(ReactLoading)`
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 50;
 `;
 
 export const LabelText = styled.p`
@@ -27,8 +41,8 @@ export const ProfileImageInput = styled.input`
 
 export const XMarkIcon = styled.span`
   position: absolute;
-  top: 30px;
-  right: 30%;
+  top: 0;
+  right: 0;
   cursor: pointer;
 `;
 

--- a/breaking-front/src/constants/path.js
+++ b/breaking-front/src/constants/path.js
@@ -18,6 +18,7 @@ export const API_PATH = {
   OAUTH2_SIGNOUT: '/oauth2/sign-out',
   OAUTH2_VALIDATE_JWT: '/oauth2/validate-jwt',
   PROFILE_EDIT: '/profile',
+  PROFILE_DETAIL_DATA: '/profile/detail',
   FOLLOW: (userId) => `/follow/${userId}`,
   UNFOLLOW: (userId) => `/follow/${userId}`,
   PROFILE_DATA: (userId) => `/profile/${userId}`,

--- a/breaking-front/src/hooks/queries/useProfileDetailData.js
+++ b/breaking-front/src/hooks/queries/useProfileDetailData.js
@@ -4,7 +4,7 @@ import { useQuery } from 'react-query';
 const useProfileDetailData = () =>
   useQuery(['getProfileDetailData'], getProfileDetailData, {
     refetchOnWindowFocus: false,
-    retry: 2,
+
     onSuccess: (data) => {
       console.log(data);
     },

--- a/breaking-front/src/hooks/queries/useProfileDetailData.js
+++ b/breaking-front/src/hooks/queries/useProfileDetailData.js
@@ -4,7 +4,7 @@ import { useQuery } from 'react-query';
 const useProfileDetailData = () =>
   useQuery(['getProfileDetailData'], getProfileDetailData, {
     refetchOnWindowFocus: false,
-
+    retry: 2,
     onSuccess: (data) => {
       console.log(data);
     },

--- a/breaking-front/src/hooks/queries/useProfileDetailData.js
+++ b/breaking-front/src/hooks/queries/useProfileDetailData.js
@@ -1,0 +1,14 @@
+import { getProfileDetailData } from 'api/profile';
+import { useQuery } from 'react-query';
+
+const useProfileDetailData = () =>
+  useQuery(['getProfileDetailData'], getProfileDetailData, {
+    refetchOnWindowFocus: false,
+
+    onSuccess: (data) => {
+      console.log(data);
+    },
+    onError: () => {},
+  });
+
+export default useProfileDetailData;

--- a/breaking-front/src/hooks/queries/useProfileDetailData.js
+++ b/breaking-front/src/hooks/queries/useProfileDetailData.js
@@ -1,4 +1,4 @@
-import { getProfileDetailData } from 'api/profile';
+import { getProfileDetailData } from 'api/profileEdit';
 import { useQuery } from 'react-query';
 
 const useProfileDetailData = () =>

--- a/breaking-front/src/mocks/handlers.js
+++ b/breaking-front/src/mocks/handlers.js
@@ -94,25 +94,4 @@ export const handlers = [
       })
     );
   }),
-
-  rest.get(API_PATH.PROFILE_DETAIL_DATA, (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json({
-        profileImgURL:
-          'https://cdn.pixabay.com/photo/2022/06/29/10/38/job-7291427_960_720.png',
-        realName: '강주혁',
-        nickname: '주기',
-        phoneNumber: '01012345678',
-        email: 'kangju2000@naver.com',
-        statusMsg: '안녕하세요!!',
-        role: 'USER',
-      })
-    );
-  }),
-
-  rest.put(API_PATH.PROFILE_EDIT, (req, res, ctx) => {
-    console.log(req.body);
-    return res(ctx.status(200));
-  }),
 ];

--- a/breaking-front/src/mocks/handlers.js
+++ b/breaking-front/src/mocks/handlers.js
@@ -94,4 +94,25 @@ export const handlers = [
       })
     );
   }),
+
+  rest.get(API_PATH.PROFILE_DETAIL_DATA, (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        profileImgURL:
+          'https://cdn.pixabay.com/photo/2022/06/29/10/38/job-7291427_960_720.png',
+        realName: '강주혁',
+        nickname: '주기',
+        phoneNumber: '01012345678',
+        email: 'kangju2000@naver.com',
+        statusMsg: '안녕하세요!!',
+        role: 'USER',
+      })
+    );
+  }),
+
+  rest.put(API_PATH.PROFILE_EDIT, (req, res, ctx) => {
+    console.log(req.body);
+    return res(ctx.status(200));
+  }),
 ];

--- a/breaking-front/src/mocks/profileHandlers.js
+++ b/breaking-front/src/mocks/profileHandlers.js
@@ -1,0 +1,25 @@
+import { API_PATH } from 'constants/path';
+import { rest } from 'msw';
+
+export const profileHandlers = [
+  rest.get(API_PATH.PROFILE_DETAIL_DATA, (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        profileImgURL:
+          'https://cdn.pixabay.com/photo/2021/09/26/09/55/seal-6656983_960_720.jpg',
+        realName: '강주혁',
+        nickname: '주기',
+        phoneNumber: '01012345678',
+        email: 'kangju2000@naver.com',
+        statusMsg: '안녕하세요!!',
+        role: 'USER',
+      })
+    );
+  }),
+
+  rest.put(API_PATH.PROFILE_EDIT, (req, res, ctx) => {
+    console.log(req.body);
+    return res(ctx.status(200));
+  }),
+];

--- a/breaking-front/src/mocks/profileHandlers.js
+++ b/breaking-front/src/mocks/profileHandlers.js
@@ -6,8 +6,7 @@ export const profileHandlers = [
     return res(
       ctx.status(200),
       ctx.json({
-        profileImgURL:
-          'https://cdn.pixabay.com/photo/2021/09/26/09/55/seal-6656983_960_720.jpg',
+        profileImgURL: '',
         realName: '강주혁',
         nickname: '주기',
         phoneNumber: '01012345678',

--- a/breaking-front/src/mocks/worker.js
+++ b/breaking-front/src/mocks/worker.js
@@ -1,4 +1,5 @@
 import { setupWorker } from 'msw';
 import { handlers } from 'mocks/handlers';
+import { profileHandlers } from './profileHandlers';
 
-export const worker = setupWorker(...handlers);
+export const worker = setupWorker(...handlers, ...profileHandlers);

--- a/breaking-front/src/pages/ProfileEdit/ProfileEdit.js
+++ b/breaking-front/src/pages/ProfileEdit/ProfileEdit.js
@@ -3,7 +3,7 @@ import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 import ProfileSettingForm from 'components/ProfileSettingForm/ProfileSettingForm';
 import useProfileDetailData from 'hooks/queries/useProfileDetailData';
-import { putProfileEdit } from 'api/profile';
+import { putProfileEdit } from 'api/profileEdit';
 import { PAGE_PATH } from 'constants/path';
 
 const ProfileEdit = () => {

--- a/breaking-front/src/pages/ProfileEdit/ProfileEdit.js
+++ b/breaking-front/src/pages/ProfileEdit/ProfileEdit.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useMutation } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+import ProfileSettingForm from 'components/ProfileSettingForm/ProfileSettingForm';
+import useProfileDetailData from 'hooks/queries/useProfileDetailData';
+import { putProfileEdit } from 'api/profile';
+import { PAGE_PATH } from 'constants/path';
+
+const ProfileEdit = () => {
+  const navigate = useNavigate();
+
+  const { data } = useProfileDetailData();
+
+  const { mutate: ProfileEditMutate } = useMutation(putProfileEdit, {
+    onSuccess: (res) => {
+      console.log(res);
+      alert('변경사항을 저장하였습니다.');
+      navigate(PAGE_PATH.HOME);
+    },
+    onError: () => {
+      //에러 페이지 이동
+    },
+  });
+
+  return (
+    <>
+      {data && (
+        <ProfileSettingForm
+          userDefaultData={data.data}
+          mutate={ProfileEditMutate}
+        />
+      )}
+    </>
+  );
+};
+
+export default ProfileEdit;

--- a/breaking-front/src/pages/ProfileEdit/ProfileEdit.js
+++ b/breaking-front/src/pages/ProfileEdit/ProfileEdit.js
@@ -8,8 +8,7 @@ import { PAGE_PATH } from 'constants/path';
 
 const ProfileEdit = () => {
   const navigate = useNavigate();
-
-  const { data } = useProfileDetailData();
+  const { data, isLoading } = useProfileDetailData();
 
   const { mutate: ProfileEditMutate } = useMutation(putProfileEdit, {
     onSuccess: (res) => {
@@ -24,12 +23,12 @@ const ProfileEdit = () => {
 
   return (
     <>
-      {data && (
-        <ProfileSettingForm
-          userDefaultData={data.data}
-          mutate={ProfileEditMutate}
-        />
-      )}
+      <ProfileSettingForm
+        isLoading={isLoading}
+        userDefaultData={data?.data}
+        mutate={ProfileEditMutate}
+      />
+      {/* 추후 탈퇴 기능 구현 */}
     </>
   );
 };

--- a/breaking-front/src/pages/ProfileEdit/ProfileEdit.js
+++ b/breaking-front/src/pages/ProfileEdit/ProfileEdit.js
@@ -24,6 +24,7 @@ const ProfileEdit = () => {
   return (
     <>
       <ProfileSettingForm
+        pageType="profileEdit"
         isLoading={isLoading}
         userDefaultData={data?.data}
         mutate={ProfileEditMutate}

--- a/breaking-front/src/pages/SignUp/SignUp.js
+++ b/breaking-front/src/pages/SignUp/SignUp.js
@@ -10,16 +10,6 @@ const SignUp = () => {
   const navigate = useNavigate();
   const location = useLocation();
 
-  const userDefaultData = {
-    profileImgURL: '',
-    realName: '',
-    nickname: '',
-    phoneNumber: '',
-    email: '',
-    statusMsg: '',
-    role: 'USER',
-  };
-
   const { mutate } = useMutation(postSignUp, {
     onSuccess: (res) => {
       const jwtToken = res.headers.authorization;
@@ -42,11 +32,7 @@ const SignUp = () => {
 
   return (
     <>
-      <ProfileSettingForm
-        username={location.state?.username}
-        userDefaultData={userDefaultData}
-        mutate={mutate}
-      />
+      <ProfileSettingForm username={location.state?.username} mutate={mutate} />
     </>
   );
 };

--- a/breaking-front/src/pages/SignUp/SignUp.js
+++ b/breaking-front/src/pages/SignUp/SignUp.js
@@ -32,7 +32,11 @@ const SignUp = () => {
 
   return (
     <>
-      <ProfileSettingForm username={location.state?.username} mutate={mutate} />
+      <ProfileSettingForm
+        pageType="signUp"
+        username={location.state?.username}
+        mutate={mutate}
+      />
     </>
   );
 };

--- a/breaking-front/src/utils/urlToFile.js
+++ b/breaking-front/src/utils/urlToFile.js
@@ -1,0 +1,11 @@
+const getFileFromUrl = async (url) => {
+  const response = await fetch(url);
+  const data = await response.blob();
+  const ext = url.split('.').pop();
+  const filename = url.split('/').pop();
+  return new File([data], filename, {
+    type: data.type || `image/${ext}`,
+  });
+};
+
+export default getFileFromUrl;


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #94 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
프로필 수정 페이지 로직을 구현했습니다.
프로필 수정 페이지의 UI는 회원가입 페이지와 거의 동일합니다. 다른 점이 있다면 submit 버튼의 글자가 회원가입에서 프로필 수정으로 바뀐 것과 기존의 유저 데이터들을 그대로 띄워주는 정도입니다.

아직 탈퇴 UI를 정하지 못해서 추가하지 않았습니다. 추후에 정해지면 추가할 예정입니다.

만약 유저가 프로필 수정페이지에서 이미지 변경을 하지 않고 수정을 했다면, 받아온 기존 이미지url을 다시 file로 바꾸어 formdata에 저장하여 보내야하므로 urlToFile util 파일을 만들어서 구현했습니다.