### PR TITLE
feat: 유저정보를 전역 state에 저장한다

### DIFF
--- a/breaking-front/src/App.js
+++ b/breaking-front/src/App.js
@@ -40,7 +40,10 @@ function App() {
                     element={<GoogleRedirect />}
                   ></Route>
                   <Route path={PAGE_PATH.SIGNUP} element={<SignUp />} />
-                  <Route path={PAGE_PATH.PROFILE} element={<Profile />} />
+                  <Route
+                    path={PAGE_PATH.PROFILE(':id')}
+                    element={<Profile />}
+                  />
                 </Routes>
               </Layout>
             </UserInformationProvider>

--- a/breaking-front/src/App.js
+++ b/breaking-front/src/App.js
@@ -13,6 +13,7 @@ import { GoogleOAuthProvider } from '@react-oauth/google';
 import Layout from 'components/Layout/Layout';
 import GoogleRedirect from 'pages/SocialLogin/Redirect/GoogleRedirect';
 import Profile from 'pages/Profile/Profile';
+import UserInformationProvider from 'providers/UserInformationProvider';
 
 function App() {
   const queryClient = new QueryClient();
@@ -22,21 +23,23 @@ function App() {
         <ThemeProvider theme={theme}>
           <GlobalStyle />
           <BrowserRouter>
-            <Layout>
-              <Routes>
-                <Route path={PAGE_PATH.LOGIN} element={<SocialLogin />} />
-                <Route
-                  path={PAGE_PATH.KAKAO_LOGIN}
-                  element={<KakaoRedirect />}
-                ></Route>
-                <Route
-                  path={PAGE_PATH.GOOGLE_LOGIN}
-                  element={<GoogleRedirect />}
-                ></Route>
-                <Route path={PAGE_PATH.SIGNUP} element={<SignUp />} />
-                <Route path={PAGE_PATH.PROFILE} element={<Profile />} />
-              </Routes>
-            </Layout>
+            <UserInformationProvider>
+              <Layout>
+                <Routes>
+                  <Route path={PAGE_PATH.LOGIN} element={<SocialLogin />} />
+                  <Route
+                    path={PAGE_PATH.KAKAO_LOGIN}
+                    element={<KakaoRedirect />}
+                  ></Route>
+                  <Route
+                    path={PAGE_PATH.GOOGLE_LOGIN}
+                    element={<GoogleRedirect />}
+                  ></Route>
+                  <Route path={PAGE_PATH.SIGNUP} element={<SignUp />} />
+                  <Route path={PAGE_PATH.PROFILE} element={<Profile />} />
+                </Routes>
+              </Layout>
+            </UserInformationProvider>
           </BrowserRouter>
         </ThemeProvider>
         <ReactQueryDevtools initialIsOpen={false} />

--- a/breaking-front/src/api/signUp.js
+++ b/breaking-front/src/api/signUp.js
@@ -18,3 +18,10 @@ export const getProfileValidation = ({ queryKey }) => {
     url: API_PATH.OAUTH2_SIGNUP_VALIDATE(query.validType, query.profileData),
   });
 };
+
+export const postJWTvalidation = () => {
+  return api({
+    method: 'post',
+    url: API_PATH.OAUTH2_VALIDATE_JWT,
+  });
+};

--- a/breaking-front/src/api/signUp.js
+++ b/breaking-front/src/api/signUp.js
@@ -19,9 +19,9 @@ export const getProfileValidation = ({ queryKey }) => {
   });
 };
 
-export const postJWTvalidation = () => {
+export const getJWTvalidation = () => {
   return api({
-    method: 'post',
+    method: 'get',
     url: API_PATH.OAUTH2_VALIDATE_JWT,
   });
 };

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -16,8 +16,7 @@ import { UserInformationContext } from 'providers/UserInformationProvider';
 export default function Header({ loginButtonClick, ...props }) {
   const [searchText, setSearchText] = useState('');
   const [isOpenToggle, setIsOpenToggle] = useState(false);
-  const { isLogin, profileImgURL } = useContext(UserInformationContext);
-
+  const { isLogin, profileImgURL, userId } = useContext(UserInformationContext);
   const onChange = (event) => {
     setSearchText(event.target.value);
   };
@@ -72,7 +71,7 @@ export default function Header({ loginButtonClick, ...props }) {
                 blueLabel="입출금내역"
               />
               <Toggle.LabelLink
-                path={PAGE_PATH.MYPAGE}
+                path={PAGE_PATH.PROFILE + `/${userId}`}
                 icon={<MyPageIcon />}
                 label="마이페이지"
               />

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
 import Input from 'components/Input/Input';
 import Line from 'components/Line/Line';
@@ -11,10 +11,12 @@ import { ReactComponent as DownArrowIcon } from 'assets/svg/down-arrow.svg';
 import { ReactComponent as MoneyIcon } from 'assets/svg/money.svg';
 import { ReactComponent as SettingIcon } from 'assets/svg/setting.svg';
 import { ReactComponent as MyPageIcon } from 'assets/svg/mypage.svg';
+import { UserInformationContext } from 'providers/UserInformationProvider';
 
-export default function Header({ isLogin, loginButtonClick, ...props }) {
+export default function Header({ loginButtonClick, ...props }) {
   const [searchText, setSearchText] = useState('');
   const [isOpenToggle, setIsOpenToggle] = useState(false);
+  const { isLogin, profileImgURL } = useContext(UserInformationContext);
 
   const onChange = (event) => {
     setSearchText(event.target.value);
@@ -49,7 +51,7 @@ export default function Header({ isLogin, loginButtonClick, ...props }) {
             onBlur={handleToggle}
             tabIndex="0"
           >
-            <Style.MyProfileImage size="small" src="" />
+            <Style.MyProfileImage size="small" src={profileImgURL} />
             <DownArrowIcon />
           </Style.ProfileContent>
         ) : (

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -71,7 +71,7 @@ export default function Header({ loginButtonClick, ...props }) {
                 blueLabel="입출금내역"
               />
               <Toggle.LabelLink
-                path={PAGE_PATH.PROFILE + `/${userId}`}
+                path={PAGE_PATH.PROFILE(userId)}
                 icon={<MyPageIcon />}
                 label="마이페이지"
               />

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -21,7 +21,7 @@ export default function Header({ isLogin, loginButtonClick, ...props }) {
   };
 
   const handleToggle = () => {
-    setIsOpenToggle((prev) => !prev);
+    setIsOpenToggle((pre) => !pre);
   };
 
   const handleSubmit = (event) => {

--- a/breaking-front/src/constants/path.js
+++ b/breaking-front/src/constants/path.js
@@ -4,7 +4,7 @@ export const PAGE_PATH = {
   KAKAO_LOGIN: 'login/kakao',
   GOOGLE_LOGIN: 'login/google',
   SIGNUP: '/signup',
-  PROFILE: '/profile/:id',
+  PROFILE: (userId) => `/profile/${userId}`,
   TRANSACTION: '/transaction',
   PROFILE_EDIT: '/profile/edit',
 };

--- a/breaking-front/src/hooks/queries/useJWTValidate.js
+++ b/breaking-front/src/hooks/queries/useJWTValidate.js
@@ -4,11 +4,11 @@ import { useContext } from 'react';
 import { useQuery } from 'react-query';
 
 const useJWTValidate = () => {
-  const { setUserInfomation } = useContext(UserInformationContext);
+  const { setUserInformation } = useContext(UserInformationContext);
   const { refetch } = useQuery(['jwtvalidate'], getJWTvalidation, {
     enabled: false,
     select: (data) => {
-      setUserInfomation({ ...data.data, isLogin: true });
+      setUserInformation({ ...data.data, isLogin: true });
     },
   });
   return { refetch };

--- a/breaking-front/src/hooks/queries/useJWTValidate.js
+++ b/breaking-front/src/hooks/queries/useJWTValidate.js
@@ -1,0 +1,17 @@
+import { getJWTvalidation } from 'api/signUp';
+import { UserInformationContext } from 'providers/UserInformationProvider';
+import { useContext } from 'react';
+import { useQuery } from 'react-query';
+
+const useJWTValidate = () => {
+  const { setUserInfomation } = useContext(UserInformationContext);
+  const { refetch } = useQuery(['jwtvalidate'], getJWTvalidation, {
+    enabled: false,
+    select: (data) => {
+      setUserInfomation({ ...data.data, isLogin: true });
+    },
+  });
+  return { refetch };
+};
+
+export default useJWTValidate;

--- a/breaking-front/src/mocks/handlers.js
+++ b/breaking-front/src/mocks/handlers.js
@@ -65,7 +65,7 @@ export const handlers = [
     else return res(ctx.status(200));
   }),
 
-  rest.post(API_PATH.OAUTH2_VALIDATE_JWT, (req, res, ctx) => {
+  rest.get(API_PATH.OAUTH2_VALIDATE_JWT, (req, res, ctx) => {
     return res(
       ctx.json({
         userId: 123454,

--- a/breaking-front/src/mocks/handlers.js
+++ b/breaking-front/src/mocks/handlers.js
@@ -2,13 +2,9 @@ import { API_PATH } from 'constants/path';
 import { rest } from 'msw';
 
 export const handlers = [
-  rest.get('https://test.api.com/test', (req, res, ctx) => {
-    return res(ctx.status(200));
-  }),
-
   rest.post(API_PATH.OAUTH2_SIGNUP, (req, res, ctx) => {
     console.log(req.body);
-    return res(ctx.status(200));
+    return res(ctx.set('Authorization', 'abcdefghijklmnop'), ctx.status(200));
   }),
 
   rest.get(
@@ -67,6 +63,18 @@ export const handlers = [
         ctx.json({ message: '이메일 형식이 잘못되었습니다.' })
       );
     else return res(ctx.status(200));
+  }),
+
+  rest.post(API_PATH.OAUTH2_VALIDATE_JWT, (req, res, ctx) => {
+    return res(
+      ctx.json({
+        userId: 123454,
+        profileImgURL: '',
+        nickname: '주기',
+        balance: 9999999999,
+      }),
+      ctx.status(200)
+    );
   }),
 
   rest.post(API_PATH.OAUTH2_SIGNIN_KAKAO, (req, res, ctx) => {

--- a/breaking-front/src/pages/SignUp/SignUp.js
+++ b/breaking-front/src/pages/SignUp/SignUp.js
@@ -1,25 +1,17 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useMutation } from 'react-query';
-import { postJWTvalidation, postSignUp } from 'api/signUp';
+import { postSignUp } from 'api/signUp';
 import { PAGE_PATH } from 'constants/path';
-import MESSAGE from 'constants/message';
+// import MESSAGE from 'constants/message';
 import ProfileSettingForm from 'components/ProfileSettingForm/ProfileSettingForm';
-import { useContext } from 'react';
-import { UserInformationContext } from 'providers/UserInformationProvider';
+import useJWTValidate from 'hooks/queries/useJWTValidate';
 
 const SignUp = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { setUserInfomation } = useContext(UserInformationContext);
-
-  const { mutate: JWTValidate } = useMutation(postJWTvalidation, {
-    onSuccess: (data) => {
-      console.log(data);
-      setUserInfomation({ ...data.data, isLogin: true });
-    },
-  });
-
+  const { refetch: JWTValidateRefetch } = useJWTValidate();
+  console.log(JWTValidateRefetch);
   const userDefaultData = {
     profileImgURL: '',
     realName: '',
@@ -35,7 +27,7 @@ const SignUp = () => {
       const jwtToken = res.headers.authorization;
       console.log(res);
       localStorage.setItem('access_token', jwtToken);
-      JWTValidate();
+      JWTValidateRefetch();
       alert('환영합니다.');
       navigate(PAGE_PATH.HOME);
     },
@@ -44,13 +36,13 @@ const SignUp = () => {
     },
   });
 
-  useEffect(() => {
-    //유저가 sns 로그인하지않고 회원가입 페이지로 들어왔을 때 처리
-    if (!location.state) {
-      alert(MESSAGE.SIGNUP.WRONG_ACCESS);
-      navigate(PAGE_PATH.LOGIN);
-    }
-  }, []);
+  // useEffect(() => {
+  //   //유저가 sns 로그인하지않고 회원가입 페이지로 들어왔을 때 처리
+  //   if (!location.state) {
+  //     alert(MESSAGE.SIGNUP.WRONG_ACCESS);
+  //     navigate(PAGE_PATH.LOGIN);
+  //   }
+  // }, []);
 
   return (
     <>

--- a/breaking-front/src/pages/SignUp/SignUp.js
+++ b/breaking-front/src/pages/SignUp/SignUp.js
@@ -1,25 +1,17 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useMutation } from 'react-query';
 import { postSignUp } from 'api/signUp';
 import { PAGE_PATH } from 'constants/path';
 import ProfileSettingForm from 'components/ProfileSettingForm/ProfileSettingForm';
 import useJWTValidate from 'hooks/queries/useJWTValidate';
+import MESSAGE from 'constants/message';
 
 const SignUp = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { refetch: JWTValidateRefetch } = useJWTValidate();
   console.log(JWTValidateRefetch);
-  const userDefaultData = {
-    profileImgURL: '',
-    realName: '',
-    nickname: '',
-    phoneNumber: '',
-    email: '',
-    statusMsg: '',
-    role: 'USER',
-  };
 
   const { mutate } = useMutation(postSignUp, {
     onSuccess: (res) => {
@@ -35,21 +27,17 @@ const SignUp = () => {
     },
   });
 
-  // useEffect(() => {
-  //   //유저가 sns 로그인하지않고 회원가입 페이지로 들어왔을 때 처리
-  //   if (!location.state) {
-  //     alert(MESSAGE.SIGNUP.WRONG_ACCESS);
-  //     navigate(PAGE_PATH.LOGIN);
-  //   }
-  // }, []);
+  useEffect(() => {
+    //유저가 sns 로그인하지않고 회원가입 페이지로 들어왔을 때 처리
+    if (!location.state) {
+      alert(MESSAGE.SIGNUP.WRONG_ACCESS);
+      navigate(PAGE_PATH.LOGIN);
+    }
+  }, []);
 
   return (
     <>
-      <ProfileSettingForm
-        username={location.state?.username}
-        userDefaultData={userDefaultData}
-        mutate={mutate}
-      />
+      <ProfileSettingForm username={location.state?.username} mutate={mutate} />
     </>
   );
 };

--- a/breaking-front/src/pages/SignUp/SignUp.js
+++ b/breaking-front/src/pages/SignUp/SignUp.js
@@ -1,14 +1,24 @@
 import React, { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useMutation } from 'react-query';
-import { postSignUp } from 'api/signUp';
+import { postJWTvalidation, postSignUp } from 'api/signUp';
 import { PAGE_PATH } from 'constants/path';
 import MESSAGE from 'constants/message';
 import ProfileSettingForm from 'components/ProfileSettingForm/ProfileSettingForm';
+import { useContext } from 'react';
+import { UserInformationContext } from 'providers/UserInformationProvider';
 
 const SignUp = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { setUserInfomation } = useContext(UserInformationContext);
+
+  const { mutate: JWTValidate } = useMutation(postJWTvalidation, {
+    onSuccess: (data) => {
+      console.log(data);
+      setUserInfomation({ ...data.data, isLogin: true });
+    },
+  });
 
   const userDefaultData = {
     profileImgURL: '',
@@ -23,7 +33,9 @@ const SignUp = () => {
   const { mutate } = useMutation(postSignUp, {
     onSuccess: (res) => {
       const jwtToken = res.headers.authorization;
+      console.log(res);
       localStorage.setItem('access_token', jwtToken);
+      JWTValidate();
       alert('환영합니다.');
       navigate(PAGE_PATH.HOME);
     },

--- a/breaking-front/src/pages/SignUp/SignUp.js
+++ b/breaking-front/src/pages/SignUp/SignUp.js
@@ -37,7 +37,11 @@ const SignUp = () => {
 
   return (
     <>
-      <ProfileSettingForm username={location.state?.username} mutate={mutate} />
+      <ProfileSettingForm
+        pageType="signup"
+        username={location.state?.username}
+        mutate={mutate}
+      />
     </>
   );
 };

--- a/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
+++ b/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
@@ -1,13 +1,13 @@
 import { postAccessCode, postSignInWithGoogle } from 'api/login';
 import { GOOGLE_PATH, PAGE_PATH } from 'constants/path';
-import { UserInformationContext } from 'providers/UserInformationProvider';
-import React, { useContext, useEffect } from 'react';
+import useJWTValidate from 'hooks/queries/useJWTValidate';
+import React, { useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 const GoogleRedirect = () => {
   const navigate = useNavigate();
-  const { setUserInfomation } = useContext(UserInformationContext);
+  const { refetch: JWTValidateRefetch } = useJWTValidate();
   const accessCode = new URL(window.location.href).searchParams.get('code');
 
   const SignInGoogle = useMutation(postSignInWithGoogle, {
@@ -16,7 +16,7 @@ const GoogleRedirect = () => {
       const jwtToken = res.headers.authorization;
       if (jwtToken) {
         localStorage.setItem('access_token', res.headers.authorization);
-        setUserInfomation(() => ({ ...res.data, isLogin: true }));
+        JWTValidateRefetch();
         navigate(PAGE_PATH.HOME);
       } else {
         navigate(PAGE_PATH.SIGNUP, { state: res.data });

--- a/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
+++ b/breaking-front/src/pages/SocialLogin/Redirect/GoogleRedirect.js
@@ -1,12 +1,13 @@
 import { postAccessCode, postSignInWithGoogle } from 'api/login';
 import { GOOGLE_PATH, PAGE_PATH } from 'constants/path';
-import React, { useEffect } from 'react';
+import { UserInformationContext } from 'providers/UserInformationProvider';
+import React, { useContext, useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 const GoogleRedirect = () => {
   const navigate = useNavigate();
-
+  const { setUserInfomation } = useContext(UserInformationContext);
   const accessCode = new URL(window.location.href).searchParams.get('code');
 
   const SignInGoogle = useMutation(postSignInWithGoogle, {
@@ -15,6 +16,7 @@ const GoogleRedirect = () => {
       const jwtToken = res.headers.authorization;
       if (jwtToken) {
         localStorage.setItem('access_token', res.headers.authorization);
+        setUserInfomation(() => ({ ...res.data, isLogin: true }));
         navigate(PAGE_PATH.HOME);
       } else {
         navigate(PAGE_PATH.SIGNUP, { state: res.data });

--- a/breaking-front/src/pages/SocialLogin/Redirect/KakaoRedirect.js
+++ b/breaking-front/src/pages/SocialLogin/Redirect/KakaoRedirect.js
@@ -1,12 +1,13 @@
 import { postAccessCode, postSignInWithKakao } from 'api/login';
 import { KAKAO_PATH, PAGE_PATH } from 'constants/path';
-import React, { useEffect } from 'react';
+import { UserInformationContext } from 'providers/UserInformationProvider';
+import React, { useContext, useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 const KakaoRedirect = () => {
   const navigate = useNavigate();
-
+  const { setUserInfomation } = useContext(UserInformationContext);
   const accessCode = new URL(window.location.href).searchParams.get('code');
 
   const SignInKakao = useMutation(postSignInWithKakao, {
@@ -15,6 +16,7 @@ const KakaoRedirect = () => {
       const jwtToken = res.headers.authorization;
       if (jwtToken) {
         localStorage.setItem('access_token', res.headers.authorization);
+        setUserInfomation(() => ({ ...res.data, isLogin: true }));
         navigate(PAGE_PATH.HOME);
       } else {
         navigate(PAGE_PATH.SIGNUP, { state: res.data });

--- a/breaking-front/src/pages/SocialLogin/Redirect/KakaoRedirect.js
+++ b/breaking-front/src/pages/SocialLogin/Redirect/KakaoRedirect.js
@@ -1,13 +1,13 @@
 import { postAccessCode, postSignInWithKakao } from 'api/login';
 import { KAKAO_PATH, PAGE_PATH } from 'constants/path';
-import { UserInformationContext } from 'providers/UserInformationProvider';
-import React, { useContext, useEffect } from 'react';
+import useJWTValidate from 'hooks/queries/useJWTValidate';
+import React, { useEffect } from 'react';
 import { useMutation } from 'react-query';
 import { useNavigate } from 'react-router-dom';
 
 const KakaoRedirect = () => {
   const navigate = useNavigate();
-  const { setUserInfomation } = useContext(UserInformationContext);
+  const { refetch: JWTValidateRefetch } = useJWTValidate();
   const accessCode = new URL(window.location.href).searchParams.get('code');
 
   const SignInKakao = useMutation(postSignInWithKakao, {
@@ -16,7 +16,7 @@ const KakaoRedirect = () => {
       const jwtToken = res.headers.authorization;
       if (jwtToken) {
         localStorage.setItem('access_token', res.headers.authorization);
-        setUserInfomation(() => ({ ...res.data, isLogin: true }));
+        JWTValidateRefetch();
         navigate(PAGE_PATH.HOME);
       } else {
         navigate(PAGE_PATH.SIGNUP, { state: res.data });

--- a/breaking-front/src/providers/UserInformationProvider.js
+++ b/breaking-front/src/providers/UserInformationProvider.js
@@ -9,6 +9,7 @@ const UserInformationProvider = ({ children }) => {
     profileImgURL: '',
     nickname: '',
     balance: null,
+    isLogin: true,
   });
 
   return (

--- a/breaking-front/src/providers/UserInformationProvider.js
+++ b/breaking-front/src/providers/UserInformationProvider.js
@@ -9,7 +9,7 @@ const UserInformationProvider = ({ children }) => {
     profileImgURL: '',
     nickname: '',
     balance: null,
-    isLogin: true,
+    isLogin: false,
   });
 
   return (

--- a/breaking-front/src/providers/UserInformationProvider.js
+++ b/breaking-front/src/providers/UserInformationProvider.js
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+import PorpTypes from 'prop-types';
+
+export const UserInformationContext = React.createContext();
+
+const UserInformationProvider = ({ children }) => {
+  const [userInfomation, setUserInfomation] = useState({
+    userId: null,
+    profileImgURL: '',
+    nickname: '',
+    balance: null,
+  });
+
+  return (
+    <UserInformationContext.Provider
+      value={{ ...userInfomation, setUserInfomation }}
+    >
+      {children}
+    </UserInformationContext.Provider>
+  );
+};
+
+UserInformationProvider.propTypes = {
+  children: PorpTypes.node,
+};
+
+export default UserInformationProvider;

--- a/breaking-front/src/providers/UserInformationProvider.js
+++ b/breaking-front/src/providers/UserInformationProvider.js
@@ -4,7 +4,7 @@ import PorpTypes from 'prop-types';
 export const UserInformationContext = React.createContext();
 
 const UserInformationProvider = ({ children }) => {
-  const [userInfomation, setUserInfomation] = useState({
+  const [userInformation, setUserInformation] = useState({
     userId: null,
     profileImgURL: '',
     nickname: '',
@@ -14,7 +14,7 @@ const UserInformationProvider = ({ children }) => {
 
   return (
     <UserInformationContext.Provider
-      value={{ ...userInfomation, setUserInfomation }}
+      value={{ ...userInformation, setUserInformation }}
     >
       {children}
     </UserInformationContext.Provider>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #113 

## 예상 리뷰 시간
8-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- 전역 state를 만들기위해 contextAPI wrapper를 생성하였습니다.
- 로그인시에 유저 정보를 받아오는 과정에 전역 state로 저장하는 로직을 추가하였습니다
- 회원가입시에 jwt토큰을 이용해서 데이터를 불러오는 로직을 추가했습니다.
- 회원가입시에 데이터를 불러와 전역 state에 저장하는 로직을 추가하였습니다.
- header에서 state에 따라서 버튼 및 프로필사진을 표시하도록 수정하였습니다

## 스크린샷
<!-- 

추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![1](https://user-images.githubusercontent.com/49224104/180122117-b8c75529-576b-4219-8117-77d96c6b41b4.gif)
로그인시에 프로필 사진이 깜빡이고 교체되는 현상이 남아있습니다 이는 전역 state 저장보다 home으로 가는속도가 더 빨라서 생기는 현상인것 같습니다 수정이 필요해보입니다. 회원가입시에서는 alert이 있어 페이지 이동에 시간을 벌수있어서 깜빡이고 교체되는 현상이 일어나지 않습니다.

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->

react-query usequery hook에서 select option을 사용하면 데이터가 변경될때마다 실행이 되어서 refetch시에도 실행할수 있었습니다.
