### PR TITLE
feat: dummy data 구조화작업

### DIFF
--- a/breaking-front/src/mocks/dummyData/contents.js
+++ b/breaking-front/src/mocks/dummyData/contents.js
@@ -1,0 +1,80 @@
+import {
+  NORMAL_USER,
+  NO_PROFILEIMGURL_USER,
+  NO_POSTCOUNT_USER,
+  NO_FOLLOW_USER,
+} from 'mocks/dummyData/users';
+
+export const NORMAL_CONTENT = {
+  postId: 1,
+  title: '사진이 아주 이뻐요',
+  region: '게더타운',
+  thumbnailImgURL:
+    'https://cdn.pixabay.com/photo/2022/04/19/09/08/flowers-7142409_960_720.jpg',
+  likeCount: 3,
+  postType: '',
+  isSold: false,
+  price: 10000,
+  viewCount: 1000,
+  userId: 0,
+  profileImgURL: NO_FOLLOW_USER.profileImgURL,
+  nickname: NO_FOLLOW_USER.nickname,
+  isLiked: true,
+  isBookmarked: false,
+  createdTime: new Date(),
+};
+
+export const EXCLUSIVE_CONTENT = {
+  postId: 1,
+  title: '사진이 아주 이뻐요',
+  region: '남극',
+  thumbnailImgURL:
+    'https://cdn.pixabay.com/photo/2022/04/29/17/48/lofoten-7164179_960_720.jpg',
+  likeCount: 10,
+  postType: 'EXCLUSIVE',
+  isSold: false,
+  price: 10000,
+  viewCount: 1000,
+  userId: 0,
+  profileImgURL: NORMAL_USER.profileImgURL,
+  nickname: NORMAL_USER.nickname,
+  isLiked: true,
+  isBookmarked: false,
+  createdTime: new Date(),
+};
+
+export const EMPTY_PICTURE_CONTENT = {
+  postId: 2,
+  title: '빈 이미지',
+  region: '서울시',
+  thumbnailImgURL: '',
+  likeCount: 0,
+  postType: '',
+  isSold: false,
+  price: 10000,
+  viewCount: 1000,
+  userId: 0,
+  profileImgURL: NO_POSTCOUNT_USER.profileImgURL,
+  nickname: NO_POSTCOUNT_USER.nickname,
+  isLiked: false,
+  isBookmarked: true,
+  createdTime: new Date(),
+};
+
+export const SOLDOUT_CONTENT = {
+  postId: 2,
+  title: '팔린글',
+  region: '서울시',
+  thumbnailImgURL: '',
+  likeCount: 0,
+  postType: '',
+  isSold: true,
+  price: 10000,
+  viewCount: 1000,
+  userId: 0,
+  profileImgURL: NO_PROFILEIMGURL_USER.profileImgURL,
+  nickname: NO_PROFILEIMGURL_USER.nickname,
+  isLiked: false,
+  isBookmarked: true,
+  createdTime: new Date(),
+};

--- a/breaking-front/src/mocks/dummyData/contents.js
+++ b/breaking-front/src/mocks/dummyData/contents.js
@@ -13,7 +13,7 @@ export const NORMAL_CONTENT = {
   thumbnailImgURL:
     'https://cdn.pixabay.com/photo/2022/04/19/09/08/flowers-7142409_960_720.jpg',
   likeCount: 3,
-  postType: 'charge',
+  postType: 'charged',
   isSold: false,
   price: 10000,
   viewCount: 1000,
@@ -50,7 +50,7 @@ export const EMPTY_PICTURE_CONTENT = {
   region: '서울시',
   thumbnailImgURL: '',
   likeCount: 0,
-  postType: 'charge',
+  postType: 'charged',
   isSold: false,
   price: 10000,
   viewCount: 1000,

--- a/breaking-front/src/mocks/dummyData/contents.js
+++ b/breaking-front/src/mocks/dummyData/contents.js
@@ -3,6 +3,7 @@ import {
   NO_PROFILEIMGURL_USER,
   NO_POSTCOUNT_USER,
   NO_FOLLOW_USER,
+  NO_STATUSMSG_USER,
 } from 'mocks/dummyData/users';
 
 export const NORMAL_CONTENT = {
@@ -12,7 +13,7 @@ export const NORMAL_CONTENT = {
   thumbnailImgURL:
     'https://cdn.pixabay.com/photo/2022/04/19/09/08/flowers-7142409_960_720.jpg',
   likeCount: 3,
-  postType: '',
+  postType: 'charge',
   isSold: false,
   price: 10000,
   viewCount: 1000,
@@ -25,13 +26,13 @@ export const NORMAL_CONTENT = {
 };
 
 export const EXCLUSIVE_CONTENT = {
-  postId: 1,
+  postId: 2,
   title: '사진이 아주 이뻐요',
   region: '남극',
   thumbnailImgURL:
     'https://cdn.pixabay.com/photo/2022/04/29/17/48/lofoten-7164179_960_720.jpg',
   likeCount: 10,
-  postType: 'EXCLUSIVE',
+  postType: 'exclusive',
   isSold: false,
   price: 10000,
   viewCount: 1000,
@@ -44,12 +45,12 @@ export const EXCLUSIVE_CONTENT = {
 };
 
 export const EMPTY_PICTURE_CONTENT = {
-  postId: 2,
+  postId: 3,
   title: '빈 이미지',
   region: '서울시',
   thumbnailImgURL: '',
   likeCount: 0,
-  postType: '',
+  postType: 'charge',
   isSold: false,
   price: 10000,
   viewCount: 1000,
@@ -62,18 +63,37 @@ export const EMPTY_PICTURE_CONTENT = {
 };
 
 export const SOLDOUT_CONTENT = {
-  postId: 2,
+  postId: 4,
   title: '팔린글',
   region: '서울시',
   thumbnailImgURL: '',
   likeCount: 0,
-  postType: '',
+  postType: 'exclusive',
   isSold: true,
   price: 10000,
   viewCount: 1000,
   userId: 0,
   profileImgURL: NO_PROFILEIMGURL_USER.profileImgURL,
   nickname: NO_PROFILEIMGURL_USER.nickname,
+  isLiked: false,
+  isBookmarked: true,
+  createdTime: new Date(),
+};
+
+export const FREE_CONTNET = {
+  postId: 5,
+  title: '공짜글',
+  region: '경기도',
+  thumbnailImgURL:
+    'https://cdn.pixabay.com/photo/2022/06/02/00/04/dog-7236774_960_720.jpg',
+  likeCount: 0,
+  postType: 'free',
+  isSold: true,
+  price: 10000,
+  viewCount: 1000,
+  userId: 0,
+  profileImgURL: NO_STATUSMSG_USER.profileImgURL,
+  nickname: NO_STATUSMSG_USER.nickname,
   isLiked: false,
   isBookmarked: true,
   createdTime: new Date(),

--- a/breaking-front/src/mocks/dummyData/users.js
+++ b/breaking-front/src/mocks/dummyData/users.js
@@ -1,0 +1,105 @@
+export const NORMAL_USER = {
+  userId: 0,
+  price: 10000,
+  profileImgURL: 'https://avatars.githubusercontent.com/u/76773202?v=4',
+  nickname: '깻묵',
+  email: 'aaaa@naver.com',
+  realName: '천진우',
+  role: '일반인',
+  statusMsg: '2022년의 천진우는 다르다',
+  followerCount: 6,
+  followingCount: 4,
+  postCount: 6,
+  isFollowing: false,
+};
+
+export const NO_STATUSMSG_USER = {
+  userId: 1,
+  price: 20000,
+  profileImgURL: 'https://avatars.githubusercontent.com/u/23312485?v=4',
+  nickname: '주기',
+  email: 'bbb@naver.com',
+  realName: '강주혁',
+  role: '일반인',
+  statusMsg: '',
+  followerCount: 4,
+  followingCount: 2,
+  postCount: 2,
+  isFollowing: false,
+};
+
+export const NO_PROFILEIMGURL_USER = {
+  userId: 2,
+  price: 100000,
+  profileImgURL: '',
+  nickname: '돌망이',
+  email: 'ccc@naver.com',
+  realName: '박태현',
+  role: '언론인',
+  statusMsg: 'Department of Software, Gachon Univ.',
+  followerCount: 4,
+  followingCount: 2,
+  postCount: 2,
+  isFollowing: false,
+};
+
+export const NO_POSTCOUNT_USER = {
+  userId: 3,
+  price: 0,
+  profileImgURL: '',
+  nickname: '만두피',
+  email: 'ddd@naver.com',
+  realName: '윤해민',
+  role: '언론인',
+  statusMsg: '한발자국만 더',
+  followerCount: 5,
+  followingCount: 5,
+  postCount: 0,
+  isFollowing: false,
+};
+
+export const NO_FOLLOW_USER = {
+  userId: 4,
+  price: 10000,
+  profileImgURL: 'https://avatars.githubusercontent.com/u/62254434?v=4',
+  nickname: '마틴',
+  email: 'eee@naver.com',
+  realName: '최현영',
+  role: '일반인',
+  statusMsg: 'Martin0o0',
+  followerCount: 0,
+  followingCount: 0,
+  postCount: 3,
+  isFollowing: false,
+};
+
+export const FOLLWOING_USER = {
+  userId: 5,
+  price: 10000,
+  profileImgURL: '',
+  nickname: '맛동산',
+  email: 'fff@naver.com',
+  realName: '김민우',
+  role: '일반인',
+  statusMsg: 'MinwuTheQuant',
+  followerCount: 1,
+  followingCount: 1,
+  postCount: 0,
+  isFollowing: true,
+};
+
+export const USER6 = {
+  userId: 6,
+  price: 10000,
+  profileImgURL: 'https://avatars.githubusercontent.com/u/54919474?v=4',
+  nickname: '머쓱',
+  email: 'ggg@naver.com',
+  realName: '신승건',
+  role: '일반인',
+  statusMsg:
+    'Department of Software, Gachon Univ. I wanna continue to grow. :)',
+  followerCount: 3,
+  followingCount: 3,
+  postCount: 1,
+  isFollowing: false,
+};

--- a/breaking-front/src/mocks/profileHandlers.js
+++ b/breaking-front/src/mocks/profileHandlers.js
@@ -1,389 +1,130 @@
 import { API_PATH } from 'constants/path';
 import { rest } from 'msw';
+import {
+  EMPTY_PICTURE_CONTENT,
+  EXCLUSIVE_CONTENT,
+  NORMAL_CONTENT,
+  SOLDOUT_CONTENT,
+} from 'mocks/dummyData/contents';
+import {
+  FOLLWOING_USER,
+  NORMAL_USER,
+  NO_FOLLOW_USER,
+  NO_POSTCOUNT_USER,
+  NO_PROFILEIMGURL_USER,
+  NO_STATUSMSG_USER,
+} from 'mocks/dummyData/users';
+
+const writtenContents = [
+  NORMAL_CONTENT,
+  EXCLUSIVE_CONTENT,
+  NORMAL_CONTENT,
+  EMPTY_PICTURE_CONTENT,
+  NORMAL_CONTENT,
+  SOLDOUT_CONTENT,
+  SOLDOUT_CONTENT,
+];
+
+const boughtContents = [
+  EXCLUSIVE_CONTENT,
+  SOLDOUT_CONTENT,
+  SOLDOUT_CONTENT,
+  SOLDOUT_CONTENT,
+  SOLDOUT_CONTENT,
+];
+
+const bookmarkedContents = [
+  NORMAL_CONTENT,
+  NORMAL_CONTENT,
+  EMPTY_PICTURE_CONTENT,
+  NORMAL_CONTENT,
+  NORMAL_CONTENT,
+  NORMAL_CONTENT,
+];
+
+const followerList = [
+  NORMAL_USER,
+  NO_STATUSMSG_USER,
+  NO_PROFILEIMGURL_USER,
+  NO_POSTCOUNT_USER,
+  NO_FOLLOW_USER,
+  FOLLWOING_USER,
+];
+
+const followingList = [
+  NORMAL_USER,
+  NO_STATUSMSG_USER,
+  NO_PROFILEIMGURL_USER,
+  NO_POSTCOUNT_USER,
+  NO_FOLLOW_USER,
+  FOLLWOING_USER,
+  NORMAL_USER,
+  NORMAL_USER,
+  NORMAL_USER,
+  NORMAL_USER,
+  NORMAL_USER,
+  NORMAL_USER,
+  NORMAL_USER,
+  NORMAL_USER,
+  NORMAL_USER,
+  NORMAL_USER,
+];
+
+const userList = [
+  NORMAL_USER,
+  NO_STATUSMSG_USER,
+  NO_PROFILEIMGURL_USER,
+  NO_POSTCOUNT_USER,
+  NO_FOLLOW_USER,
+  FOLLWOING_USER,
+];
 
 export const profileHandlers = [
-  rest.get(API_PATH.PROFILE_WRITTEN(0, 'all'), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          postId: '1',
-          title: '~~~사건',
-          region: '중구',
-          thumbnailImgURL:
-            'https://cdn.pixabay.com/photo/2022/04/29/17/48/lofoten-7164179_960_720.jpg',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-        {
-          postId: '2',
-          title: '~~~사건',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-      ])
-    );
+  rest.get(API_PATH.PROFILE_WRITTEN('*', 'all'), (req, res, ctx) => {
+    const soldOption = req.url.searchParams.get('sold-option');
+    const data = writtenContents.filter((item) => {
+      if (soldOption === 'unsold') return !item.isSold;
+      else if (soldOption === 'sold') return item.isSold;
+      else return item;
+    });
+    return res(ctx.status(200), ctx.json(data));
   }),
 
-  rest.get(API_PATH.PROFILE_BOUGHT(0, 'all'), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          postId: '3',
-          title: '제목이다',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-        {
-          postId: '4',
-          title: '~~~다른제목',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-      ])
-    );
+  rest.get(API_PATH.PROFILE_BOUGHT('*', 'all'), (req, res, ctx) => {
+    const soldOption = req.url.searchParams.get('sold-option');
+    const data = boughtContents.filter((item) => {
+      if (soldOption === 'unsold') return !item.isSold;
+      else if (soldOption === 'sold') return item.isSold;
+      else return item;
+    });
+    return res(ctx.status(200), ctx.json(data));
   }),
 
-  rest.get(API_PATH.PROFILE_BOOKMARKED(0, 'all'), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          postId: '6',
-          title: '~~~사건',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-        {
-          postId: '7',
-          title: '~~~사건',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-        {
-          postId: '8',
-          title: '~~~사건',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-        {
-          postId: '9',
-          title: '~~~사건',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-      ])
-    );
+  rest.get(API_PATH.PROFILE_BOOKMARKED('*', 'all'), (req, res, ctx) => {
+    const soldOption = req.url.searchParams.get('sold-option');
+    const data = bookmarkedContents.filter((item) => {
+      if (soldOption === 'unsold') return !item.isSold;
+      else if (soldOption === 'sold') return item.isSold;
+      else return item;
+    });
+    return res(ctx.status(200), ctx.json(data));
   }),
 
   rest.get(API_PATH.PROFILE_DATA(0), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json({
-        userId: 0,
-        profileImgURL: '',
-        nickname: '만두피',
-        email: '',
-        realName: '',
-        role: '',
-        statusMsg: '안녕하세요',
-        followerCount: 30,
-        followingCount: 30,
-        postCount: 5,
-        isFollowing: false,
-      })
-    );
+    return res(ctx.status(200), ctx.json(NORMAL_USER));
   }),
 
-  rest.get(API_PATH.PROFILE_FOLLOWERS(0), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          userId: '32',
-          nickname: '주기',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-        {
-          userId: '23',
-          nickname: '자기',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-        {
-          userId: '65',
-          nickname: '저기',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-      ])
-    );
+  rest.get(API_PATH.PROFILE_FOLLOWERS('*'), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(followerList));
   }),
-  rest.get(API_PATH.PROFILE_FOLLOWINGS(0), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          userId: '32',
-          nickname: '만두피',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-        {
-          userId: '23',
-          nickname: '천두피',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-        {
-          userId: '65',
-          nickname: '백두피',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-      ])
-    );
+  rest.get(API_PATH.PROFILE_FOLLOWINGS('*'), (req, res, ctx) => {
+    return res(ctx.status(200), ctx.json(followingList));
   }),
 
-  rest.get(API_PATH.PROFILE_WRITTEN(1, 'all'), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          postId: '1',
-          title: '~~~사건',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-        {
-          postId: '2',
-          title: '~~~사건',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-      ])
-    );
-  }),
-  rest.get(API_PATH.PROFILE_WRITTEN(1, 'sold'), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          postId: '1',
-          title: '팔린글',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-        {
-          postId: '2',
-          title: '~~~팔렸어요',
-          region: '중구',
-          thumbnailImgURL: '',
-          likeCount: 999,
-          postType: 'EXCLUSIVE',
-          isSold: false,
-          price: 10000,
-          viewCount: 1000,
-          userId: 123,
-          profileImgURL: '',
-          realName: '가나다',
-          isLiked: false,
-          isBookmarked: false,
-          createdTime: new Date(),
-        },
-      ])
-    );
-  }),
-
-  rest.get(API_PATH.PROFILE_DATA(1), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json({
-        userId: 0,
-        profileImgURL: '',
-        nickname: '만두피',
-        email: '',
-        realName: '',
-        role: '',
-        statusMsg: '안녕하세요',
-        followerCount: 30,
-        followingCount: 30,
-        postCount: 5,
-        isFollowing: false,
-      })
-    );
-  }),
-
-  rest.get(API_PATH.PROFILE_FOLLOWERS(1), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          userId: '32',
-          nickname: '주기',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-        {
-          userId: '23',
-          nickname: '자기',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-        {
-          userId: '65',
-          nickname: '저기',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-      ])
-    );
-  }),
-  rest.get(API_PATH.PROFILE_FOLLOWINGS(1), (req, res, ctx) => {
-    return res(
-      ctx.status(200),
-      ctx.json([
-        {
-          userId: '32',
-          nickname: '만두피',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-        {
-          userId: '23',
-          nickname: '천두피',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-        {
-          userId: '65',
-          nickname: '백두피',
-          statusMsg: '안녕하세요',
-          profileImgURL: '',
-        },
-      ])
-    );
+  rest.get(API_PATH.PROFILE_DATA(':userId'), (req, res, ctx) => {
+    const { userId } = req.params;
+    const user = userList.filter((item) => item.userId === Number(userId));
+    return res(ctx.status(200), ctx.json(...user));
   }),
 
   rest.post(API_PATH.FOLLOW(1), (req, res, ctx) => {

--- a/breaking-front/src/mocks/signInHandlers.js
+++ b/breaking-front/src/mocks/signInHandlers.js
@@ -1,17 +1,10 @@
 import { API_PATH } from 'constants/path';
 import { rest } from 'msw';
+import { NORMAL_USER } from 'mocks/dummyData/users';
 
 export const signInHandlers = [
   rest.get(API_PATH.OAUTH2_VALIDATE_JWT, (req, res, ctx) => {
-    return res(
-      ctx.json({
-        userId: 123454,
-        profileImgURL: '',
-        nickname: '주기',
-        balance: 9999999999,
-      }),
-      ctx.status(200)
-    );
+    return res(ctx.json(NORMAL_USER), ctx.status(200));
   }),
 
   rest.post(API_PATH.OAUTH2_SIGNIN_KAKAO, (req, res, ctx) => {
@@ -32,11 +25,8 @@ export const signInHandlers = [
   rest.post(API_PATH.OAUTH2_SIGNIN_GOOGLE, (req, res, ctx) => {
     return res(
       ctx.status(200),
-      ctx.set('Authorization', 'Bearer abcdefghijklmnop'),
-      ctx.json({
-        profileImgURL: 'URL',
-        nickname: '만두피',
-      })
+      ctx.set('Authorization', 'a2bcd412ed1!n32op'),
+      ctx.json(NORMAL_USER)
     );
   }),
 ];


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #125 
#121

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- user와 content의 dummy데이터를 생성해서 이를 가지고 msw에 적용하였습니다 데이터는 팀원들의 깃허브를 참조해서 만들었습니다. 코드량이 확실히 많이 줄고 더 직관적으로 바뀐것 같네요.
- 제가 만든곳은 데이터를 적용했는데 주기님이 만드신 부분은 데이터가 적용될만큼 유의미 한거 같지 않아서 적용을 안했습니다.
- msw도 동적으로 처리할수 있어서 라우터랑 똑같이 처리하였습니다 
- 주소창에 profile/0~6까지 확인이 가능합니다 또한 modal창에서 프로필 클릭시 해당 프로필로 넘어가도록 되어있습니다. 다만 버그가 좀 있습니다 해당내용은 #121 에 추가하였습니다. 



## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/49224104/180632795-33bff7f7-649e-413d-b835-75ed332a7e24.png)

![image](https://user-images.githubusercontent.com/49224104/180632801-c6279e2e-1eb1-435e-ad18-ea197bd3f942.png)

![image](https://user-images.githubusercontent.com/49224104/180632806-1ddcf988-67b2-4ed7-900a-a4fde8189651.png)

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
1. 이름은 일단 제가 임의로 구분이 필요한 내용으로 분류하였습니다 혹시 더 구분이 필요하거나 아이디어가 있으면 적어주시면 감사하겠습니다.
2. 유저들은 저희 팀원 으로 만들었습니다 그러다보니 USER6이라는 데이터가 남아버렸는데 나중에 구별이 필요하시면 쓰면 될것 같습니다
3. 메인을 만들때 이 dummy data를 활용하면 좋아보입니다.
