### PR TITLE
refactor: api sheet에 따른 path 추가 및 변수명 통일

### DIFF
--- a/breaking-front/src/api/profile.js
+++ b/breaking-front/src/api/profile.js
@@ -51,13 +51,13 @@ export const getFollowings = ({ queryKey }) => {
 export const postFollow = (userId) => {
   return api({
     method: 'post',
-    url: API_PATH.FOLLOW(userId),
+    url: API_PATH.PROFILE_FOLLOW(userId),
   });
 };
 
 export const postUnFollow = (userId) => {
   return api({
     method: 'delete',
-    url: API_PATH.UNFOLLOW(userId),
+    url: API_PATH.PROFILE_UNFOLLOW(userId),
   });
 };

--- a/breaking-front/src/constants/path.js
+++ b/breaking-front/src/constants/path.js
@@ -17,16 +17,16 @@ export const API_PATH = {
   OAUTH2_SIGNIN_GOOGLE: '/oauth2/sign-in/google',
   OAUTH2_SIGNOUT: '/oauth2/sign-out',
   OAUTH2_VALIDATE_JWT: '/oauth2/validate-jwt',
-  PROFILE_EDIT: '/profile',
   PROFILE_DETAIL_DATA: '/profile/detail',
-  FOLLOW: (userId) => `/follow/${userId}`,
-  UNFOLLOW: (userId) => `/follow/${userId}`,
+  PROFILE_EDIT: '/profile',
   PROFILE_DATA: (userId) => `/profile/${userId}`,
-  PROFILE_WRITTEN: (userId, option) =>
+  PROFILE_FOLLOW: (userId) => `/follow/${userId}`,
+  PROFILE_UNFOLLOW: (userId) => `/follow/${userId}`,
+  PROFILE_WRITTEN: (userId, option = 'all') =>
     `/feed/user/${userId}/write?sold-option=${option}`,
-  PROFILE_BOUGHT: (userId, option) =>
+  PROFILE_BOUGHT: (userId, option = 'all') =>
     `/feed/user/${userId}/buy?sold-option=${option}`,
-  PROFILE_BOOKMARKED: (userId, option) =>
+  PROFILE_BOOKMARKED: (userId, option = 'all') =>
     `/feed/user/${userId}/bookmark?sold-option=${option}`,
   PROFILE_FOLLOWINGS: (userId) => `/follow/following/${userId}`,
   PROFILE_FOLLOWERS: (userId) => `/follow/follower/${userId}`,
@@ -44,24 +44,28 @@ export const API_PATH = {
     option = 'all'
   ) =>
     `/feeds?page=${page}&size=${size}&hashtag=${hashtag}&sort=${sort}&sold-option=${option}`,
-  ADD_POST: '/post',
-  EDIT_POST: (postId) => `/post/${postId}`,
-  DELETE_POST: (postId) => `/post/${postId}`,
+  POST_WRITE: '/post',
+  POST_DATA: (postId) => `/post/${postId}`,
+  POST_EDIT: (postId) => `/post/${postId}`,
+  POST_DELETE: (postId) => `/post/${postId}`,
   POST_LIKE: (postId) => `/post/${postId}/like`,
-  DELETE_POST_LIKE: (postId) => `/post/${postId}/like`,
+  POST_LIKE_DELETE: (postId) => `/post/${postId}/like`,
   POST_BOOKMARK: (postId) => `/post/${postId}/bookmark`,
-  DELETE_POST_BOOKMARK: (postId) => `/post/${postId}/bookmark`,
+  POST_BOOKMARK_DELETE: (postId) => `/post/${postId}/bookmark`,
   POST_LIKE_LIST: (postId) => `/post/${postId}/like-list`,
   POST_BOUGHT_LIST: (postId) => `/post/${postId}/buy-list`,
   POST_BUY: (postId, userId) => `/post/${postId}/purchase/${userId}`,
-  POST_COMMENT: (postId) => `/post/${postId}/comment`,
-  POST_NESTED_COMMENT: (postId, commentId) =>
-    `/post/${postId}/comment/${commentId}`,
-  POST_COMMENT_LIKE: (commentId) => `/post/comment/${commentId}/like`,
-  DELETE_POST_COMMENT_LIKE: (commentId) => `/post/comment/${commentId}/like`,
-  POST_COMMENT_LIKED_LIST: (commentId) => `/post/comment/${commentId}like-list`,
+  POST_COMMENT_DATA: (postId, cursorId, size) =>
+    `/post/${postId}/comment?cursor=${cursorId}&size=${size}`,
+  POST_REPLY_DATA: (commentId, cursorId, size) =>
+    `/post/reply/${commentId}?cursor=${cursorId}&size=${size}`,
+  POST_COMMENT_WRITE: (postId) => `/post/${postId}/comment`,
+  POST_REPLY_WRITE: (commentId) => `/post/comment/${commentId}/reply`,
   POST_COMMENT_EDIT: (commentId) => `/post/comment/${commentId}`,
-  DELETE_POST_COMMENT: (commentId) => `/post/comment/${commentId}`,
+  POST_COMMENT_DELETE: (commentId) => `/post/comment/${commentId}`,
+  POST_COMMENT_LIKE: (commentId) => `/post/comment/${commentId}/like`,
+  POST_COMMENT_LIKE_DELETE: (commentId) => `/post/comment/${commentId}/like`,
+  POST_COMMENT_LIKED_LIST: (commentId) => `/post/comment/${commentId}like-list`,
   BREAKING_MISSION: '/breaking-mission',
   BREAKING_SPOT: '/breaking-spot',
 };

--- a/breaking-front/src/mocks/profileHandlers.js
+++ b/breaking-front/src/mocks/profileHandlers.js
@@ -127,10 +127,10 @@ export const profileHandlers = [
     return res(ctx.status(200), ctx.json(...user));
   }),
 
-  rest.post(API_PATH.FOLLOW(1), (req, res, ctx) => {
+  rest.post(API_PATH.PROFILE_FOLLOW(1), (req, res, ctx) => {
     return res(ctx.status(200));
   }),
-  rest.post(API_PATH.UNFOLLOW(1), (req, res, ctx) => {
+  rest.post(API_PATH.PROFILE_UNFOLLOW(1), (req, res, ctx) => {
     return res(ctx.status(200));
   }),
 ];


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #134 

## 예상 리뷰 시간
2-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
api sheet에 path가 추가되어서 그 부분을 추가하고, 변수명을 통일했습니다.
Profile 관련 api들은 변수명 앞에 PROFILE 이 붙도록 하고, 
Post 관련 api들은 POST가 붙도록 변경했습니다.
