### PR TITLE
fix: tabs의 type name을 비교하는 대신 displayName을 지정 및 비교로 수정

### DIFF
--- a/breaking-front/src/components/Tabs/Tabs.js
+++ b/breaking-front/src/components/Tabs/Tabs.js
@@ -8,7 +8,7 @@ export default function Tabs({ children, ...props }) {
   return (
     <Style.TabsContainer {...props}>
       {children.map((child, key) => {
-        if (child.type?.name === 'TabPanel') {
+        if (child.type?.displayName === 'TabPanel') {
           index++;
           return React.cloneElement(child, {
             active,
@@ -16,7 +16,7 @@ export default function Tabs({ children, ...props }) {
             index,
             key: `${key}-TabPanel`,
           });
-        } else if (child.type?.name === 'TabList') {
+        } else if (child.type?.displayName === 'TabList') {
           return React.cloneElement(child, {
             active,
             setActive,
@@ -73,7 +73,9 @@ function TabPanel({ active, index, children, ...props }) {
 }
 
 Tabs.TabList = TabList;
+TabList.displayName = 'TabList';
 Tabs.TabItem = TabItem;
+TabPanel.displayName = 'TabPanel';
 Tabs.TabPanel = TabPanel;
 
 Tabs.propTypes = {


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #141 

## 예상 리뷰 시간
0-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
기존에 tabs 컴포넌트를 만들떄 child type의 name으로 TabPanel과 TabList를 구별했었는데 이것을 displayName으로 변경하였습니다

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
ref로 별의별짓 다했는데 event를 발생시키게 할수는 있는데 dom에 있는 값을 바꾸는건 불가능했습니다. 검색도중에 displayName이 보였고 적용해봤는데 되더라고요..... 직접 지정해 주는거 방법 이여서 빌드시에도 값이 바뀌지 않습니다
