### PR TITLE
fix: 컴포넌트 오류 수정 및 일부 기능 추가

### DIFF
--- a/breaking-front/.storybook/preview.js
+++ b/breaking-front/.storybook/preview.js
@@ -1,17 +1,25 @@
 import React from 'react';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import GlobalStyle from 'styles/GlobalStyle';
 import theme from 'styles/theme';
 
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { refetchOnWindowFocus: false },
+  },
+});
 export const decorators = [
   (Story) => (
-    <ThemeProvider theme={theme}>
-      <GlobalStyle />
-      <MemoryRouter initialEntries={['/']}>
-        <Story />
-      </MemoryRouter>
-    </ThemeProvider>
+    <QueryClientProvider client={queryClient}>
+      <ThemeProvider theme={theme}>
+        <GlobalStyle />
+        <MemoryRouter initialEntries={['/']}>
+          <Story />
+        </MemoryRouter>
+      </ThemeProvider>
+    </QueryClientProvider>
   ),
 ];
 

--- a/breaking-front/src/api/post.js
+++ b/breaking-front/src/api/post.js
@@ -16,8 +16,8 @@ export const getPostCommentData = async ({ queryKey, pageParam = 0 }) => {
     url: API_PATH.POST_COMMENT_DATA(postId, pageParam),
   });
   return {
-    result: data.comment,
-    cursor: data.comment[data.comment.length - 1].commentId,
+    result: data,
+    cursor: data[data.length - 1].commentId,
   };
 };
 
@@ -28,8 +28,8 @@ export const getPostReplyData = async ({ queryKey, pageParam = 0 }) => {
     url: API_PATH.POST_REPLY_DATA(commentId, pageParam),
   });
   return {
-    result: data.comment,
-    cursor: data.comment[data.comment.length - 1].commentId,
+    result: data,
+    cursor: data[data.length - 1].commentId,
   };
 };
 

--- a/breaking-front/src/components/Feed/Feed.js
+++ b/breaking-front/src/components/Feed/Feed.js
@@ -120,7 +120,9 @@ export default function Feed({ feedData, userId, ...props }) {
               판매중
             </Button>
           )}
-          <Style.ViewCount>조회 {feedData.viewCount}</Style.ViewCount>
+          <Style.ViewCount>
+            조회 {feedData.viewCount.toLocaleString('ko-KR')}
+          </Style.ViewCount>
         </Style.Context>
         <Style.ContentStatus>
           <Style.Price>{feedData.price.toLocaleString('ko-KR')} 원</Style.Price>

--- a/breaking-front/src/components/Feed/Feed.js
+++ b/breaking-front/src/components/Feed/Feed.js
@@ -15,6 +15,7 @@ import { ReactComponent as EditIcon } from 'assets/svg/edit.svg';
 import { ReactComponent as RemoveIcon } from 'assets/svg/remove.svg';
 import { ReactComponent as ShareIcon } from 'assets/svg/share.svg';
 import { ReactComponent as HideIcon } from 'assets/svg/hide.svg';
+import { PAGE_PATH } from 'constants/path';
 
 export default function Feed({ feedData, userId, ...props }) {
   const navigate = useNavigate();
@@ -25,11 +26,11 @@ export default function Feed({ feedData, userId, ...props }) {
   const [isOpenToggle, setIsOpenToggle] = useState(false);
 
   const handleFeedClick = () => {
-    navigate(`/post/${feedData.postId}`);
+    navigate(PAGE_PATH.POST(feedData.postId));
   };
 
   const handleProfileClick = () => {
-    navigate(`/profile/${feedData.userId}`);
+    navigate(PAGE_PATH.PROFILE(feedData.userId));
   };
 
   const toggleLiked = () => {
@@ -76,7 +77,7 @@ export default function Feed({ feedData, userId, ...props }) {
             {feedData.region}
           </Style.Detail>
           <Style.Detail>{feedData.createdTime}</Style.Detail>
-          {feedData.postType === 'EXCLUSIVE' && (
+          {feedData.postType === 'exclusive' && (
             <Button color="dark" size="small" disabled>
               단독
             </Button>
@@ -90,25 +91,27 @@ export default function Feed({ feedData, userId, ...props }) {
               판매중
             </Button>
           )}
-          <Style.Price>{feedData.price.toLocaleString('ko-KR')} 원</Style.Price>
+          <Style.ViewCount>조회 {feedData.viewCount}</Style.ViewCount>
         </Style.Context>
-
-        <Style.Icons>
-          <Style.IconContainer onClick={toggleLiked}>
-            {isLiked ? <LikedIcon /> : <LikeIcon />}
-            <Style.Count>{likeCount.toLocaleString('ko-KR')}</Style.Count>
-          </Style.IconContainer>
-          <Style.IconContainer onClick={toggleBookmarked}>
-            {isBookmarked ? <BookMarkedIcon /> : <BookMarkIcon />}
-          </Style.IconContainer>
-          <Style.IconContainer
-            onClick={toggleETC}
-            tabIndex="0"
-            onBlur={() => setIsOpenToggle(false)}
-          >
-            <ETCIcon />
-          </Style.IconContainer>
-        </Style.Icons>
+        <Style.ContentStatus>
+          <Style.Price>{feedData.price.toLocaleString('ko-KR')} 원</Style.Price>
+          <Style.Icons>
+            <Style.IconContainer onClick={toggleLiked}>
+              {isLiked ? <LikedIcon /> : <LikeIcon />}
+              <Style.Count>{likeCount.toLocaleString('ko-KR')}</Style.Count>
+            </Style.IconContainer>
+            <Style.IconContainer onClick={toggleBookmarked}>
+              {isBookmarked ? <BookMarkedIcon /> : <BookMarkIcon />}
+            </Style.IconContainer>
+            <Style.IconContainer
+              onClick={toggleETC}
+              tabIndex="0"
+              onBlur={() => setIsOpenToggle(false)}
+            >
+              <ETCIcon />
+            </Style.IconContainer>
+          </Style.Icons>
+        </Style.ContentStatus>
         <Style.FeedToggle onMouseDown={(event) => event.preventDefault()}>
           {isOpenToggle &&
             (userId === feedData.userId ? (

--- a/breaking-front/src/components/Feed/Feed.js
+++ b/breaking-front/src/components/Feed/Feed.js
@@ -49,8 +49,14 @@ export default function Feed({ feedData, userId, ...props }) {
   };
 
   const toggleLiked = () => {
-    isLiked ? DeletePostLike(feedData.postId) : PostLike(feedData.postId);
-    setLikeCount((pre) => (isLiked ? pre - 1 : pre + 1));
+    if (isLiked) {
+      DeletePostLike(feedData.postId);
+      setLikeCount((pre) => pre - 1);
+    } else {
+      PostLike(feedData.postId);
+      setLikeCount((pre) => pre + 1);
+    }
+
     setIsLiked((pre) => !pre);
   };
   const toggleBookmarked = () => {
@@ -146,7 +152,6 @@ export default function Feed({ feedData, userId, ...props }) {
         <Style.FeedToggle onMouseDown={(event) => event.preventDefault()}>
           {isOpenToggle &&
             (userId === feedData.userId ? (
-              // 추후 로직 작성
               <Toggle width="80px">
                 <Toggle.LabelLink icon={<EditIcon />} label="수정" />
                 <Toggle.LabelLink

--- a/breaking-front/src/components/Feed/Feed.stories.js
+++ b/breaking-front/src/components/Feed/Feed.stories.js
@@ -22,6 +22,7 @@ const Template = (args) => {
     realName: '가나다',
     isLiked: false,
     isBookmarked: false,
+    createdTime: '2022-08-01T07:53:36.992Z',
   };
 
   return <Feed feedData={feedData} {...args} />;

--- a/breaking-front/src/components/Feed/Feed.styles.js
+++ b/breaking-front/src/components/Feed/Feed.styles.js
@@ -2,6 +2,7 @@ import styled from 'styled-components';
 import logo from 'assets/svg/logo.svg';
 
 export const Feed = styled.div`
+  display: ${({ isDeleted }) => (isDeleted ? 'none' : 'block')};
   width: 400px;
   height: 400px;
   background-color: ${({ theme }) => theme.gray[50]};

--- a/breaking-front/src/components/Feed/Feed.styles.js
+++ b/breaking-front/src/components/Feed/Feed.styles.js
@@ -25,7 +25,7 @@ export const Content = styled.div`
   display: flex;
   width: 100%;
   height: 100px;
-  padding: 10px;
+  padding: 0px 10px;
   align-items: center;
 `;
 
@@ -40,33 +40,42 @@ export const Context = styled.div`
 
 export const Title = styled.a`
   font-size: 18px;
-  font-weight: bold;
+  font-weight: 700;
   cursor: pointer;
 `;
 
 export const Detail = styled.div`
+  display: flex;
   font-size: 12px;
   color: ${({ theme }) => theme.gray[800]};
 `;
 
-export const Price = styled.p`
-  display: inline;
-  font-size: 12px;
-  font-weight: bold;
+export const ViewCount = styled(Detail)`
+  display: inline-block;
+`;
+
+export const Price = styled.h3`
+  margin-bottom: 10px;
   color: ${({ theme }) => theme.blue[900]};
+  font-size: 18px;
+  font-weight: 700;
+  text-align: center;
 `;
 
 export const IconContainer = styled.div`
   display: flex;
-  justify-content: center;
   align-items: center;
   margin-left: 8px;
   cursor: pointer;
 `;
 
+export const ContentStatus = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
 export const Icons = styled.div`
   display: flex;
-  align-items: center;
 `;
 
 export const Count = styled.span`

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -67,10 +67,12 @@ export default function Header({ loginButtonClick, ...props }) {
         <Style.ProfileToggle onMouseDown={(event) => event.preventDefault()}>
           {isOpenToggle && (
             <Toggle width="220px" isArrowMark={true}>
+              <Style.BlueLabel onClick={() => navigate(PAGE_PATH.TRANSACTION)}>
+                입출금내역
+              </Style.BlueLabel>
               <Toggle.LabelLink
                 icon={<MoneyIcon />}
                 label="10,000원"
-                blueLabel="입출금내역"
                 labelClick={() => navigate(PAGE_PATH.TRANSACTION)}
               />
               <Toggle.LabelLink

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -1,7 +1,6 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
-import { UserInformationContext } from 'providers/UserInformationProvider';
 import { PAGE_PATH } from 'constants/path';
 import Input from 'components/Input/Input';
 import Line from 'components/Line/Line';
@@ -15,11 +14,17 @@ import { ReactComponent as MoneyIcon } from 'assets/svg/money.svg';
 import { ReactComponent as SettingIcon } from 'assets/svg/setting.svg';
 import { ReactComponent as MyPageIcon } from 'assets/svg/mypage.svg';
 
-export default function Header({ loginButtonClick, ...props }) {
+export default function Header({
+  isLogin,
+  profileImgURL,
+  userId,
+  loginButtonClick,
+  ...props
+}) {
   const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
   const [isOpenToggle, setIsOpenToggle] = useState(false);
-  const { isLogin, profileImgURL, userId } = useContext(UserInformationContext);
+
   const onChange = (event) => {
     setSearchText(event.target.value);
   };
@@ -97,5 +102,7 @@ export default function Header({ loginButtonClick, ...props }) {
 
 Header.propTypes = {
   isLogin: PropTypes.bool,
+  profileImgURL: PropTypes.string,
+  userId: PropTypes.number,
   loginButtonClick: PropTypes.func,
 };

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -1,5 +1,6 @@
 import React, { useContext, useState } from 'react';
 import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
 import { UserInformationContext } from 'providers/UserInformationProvider';
 import { PAGE_PATH } from 'constants/path';
 import Input from 'components/Input/Input';
@@ -15,6 +16,7 @@ import { ReactComponent as SettingIcon } from 'assets/svg/setting.svg';
 import { ReactComponent as MyPageIcon } from 'assets/svg/mypage.svg';
 
 export default function Header({ loginButtonClick, ...props }) {
+  const navigate = useNavigate();
   const [searchText, setSearchText] = useState('');
   const [isOpenToggle, setIsOpenToggle] = useState(false);
   const { isLogin, profileImgURL, userId } = useContext(UserInformationContext);
@@ -48,7 +50,7 @@ export default function Header({ loginButtonClick, ...props }) {
         {isLogin ? (
           <Style.ProfileContent
             onClick={handleToggle}
-            onBlur={handleToggle}
+            onBlur={() => setIsOpenToggle(false)}
             tabIndex="0"
           >
             <ProfileImage size="small" src={profileImgURL} />
@@ -66,20 +68,20 @@ export default function Header({ loginButtonClick, ...props }) {
           {isOpenToggle && (
             <Toggle width="220px" isArrowMark={true}>
               <Toggle.LabelLink
-                path={PAGE_PATH.TRANSACTION}
                 icon={<MoneyIcon />}
                 label="10,000원"
                 blueLabel="입출금내역"
+                labelClick={() => navigate(PAGE_PATH.TRANSACTION)}
               />
               <Toggle.LabelLink
-                path={PAGE_PATH.PROFILE(userId)}
                 icon={<MyPageIcon />}
                 label="마이페이지"
+                labelClick={() => navigate(PAGE_PATH.PROFILE(userId))}
               />
               <Toggle.LabelLink
-                path={PAGE_PATH.PROFILE_EDIT}
                 icon={<SettingIcon />}
                 label="프로필 수정"
+                labelClick={() => navigate(PAGE_PATH.PROFILE_EDIT)}
               />
               <Line width="200" />
               <Style.Logout>로그아웃</Style.Logout>

--- a/breaking-front/src/components/Header/Header.styles.js
+++ b/breaking-front/src/components/Header/Header.styles.js
@@ -54,6 +54,16 @@ export const ProfileToggle = styled.div`
   right: -16px;
 `;
 
+export const BlueLabel = styled.span`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  font-size: 12px;
+  color: ${({ theme }) => theme.blue[900]};
+  font-weight: 700;
+  cursor: pointer;
+`;
+
 export const Logout = styled.p`
   text-align: center;
   margin: 10px;

--- a/breaking-front/src/components/Layout/Layout.js
+++ b/breaking-front/src/components/Layout/Layout.js
@@ -1,16 +1,24 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import * as Style from 'components/Layout/Layout.styles';
 import Header from 'components/Header/Header';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { PAGE_PATH } from 'constants/path';
+import { UserInformationContext } from 'providers/UserInformationProvider';
 
-export default function Layout({ isLogin, children }) {
+export default function Layout({ children }) {
   const navigate = useNavigate();
+  const { isLogin, profileImgURL, userId } = useContext(UserInformationContext);
+
   const moveLoginPage = () => navigate(PAGE_PATH.LOGIN);
   return (
     <>
-      <Header isLogin={isLogin} loginButtonClick={moveLoginPage} />
+      <Header
+        isLogin={isLogin}
+        profileImgURL={profileImgURL}
+        userId={userId}
+        loginButtonClick={moveLoginPage}
+      />
       <Style.Container>{children}</Style.Container>
     </>
   );

--- a/breaking-front/src/components/Toggle/Toggle.js
+++ b/breaking-front/src/components/Toggle/Toggle.js
@@ -11,9 +11,9 @@ export default function Toggle({ isArrowMark, width, children }) {
   );
 }
 
-function LabelLink({ path, label, blueLabel, icon, ...props }) {
+function LabelLink({ labelClick, label, blueLabel, icon }) {
   return (
-    <Style.LabelLink to={path} {...props}>
+    <Style.LabelLink onClick={labelClick}>
       {icon}
       <Style.LabelText>{label}</Style.LabelText>
       {blueLabel && <Style.BlueLabel>{blueLabel}</Style.BlueLabel>}
@@ -35,7 +35,7 @@ Toggle.defaultProps = {
 };
 
 LabelLink.propTypes = {
-  path: PropTypes.string,
+  labelClick: PropTypes.func,
   icon: PropTypes.node,
   label: PropTypes.string,
   blueLabel: PropTypes.string,

--- a/breaking-front/src/components/Toggle/Toggle.js
+++ b/breaking-front/src/components/Toggle/Toggle.js
@@ -11,12 +11,13 @@ export default function Toggle({ isArrowMark, width, children }) {
   );
 }
 
-function LabelLink({ labelClick, label, blueLabel, icon }) {
+function LabelLink({ labelClick, label, icon }) {
   return (
-    <Style.LabelLink onClick={labelClick}>
-      {icon}
-      <Style.LabelText>{label}</Style.LabelText>
-      {blueLabel && <Style.BlueLabel>{blueLabel}</Style.BlueLabel>}
+    <Style.LabelLink>
+      <Style.Label onClick={labelClick}>
+        {icon}
+        <Style.LabelText>{label}</Style.LabelText>
+      </Style.Label>
     </Style.LabelLink>
   );
 }
@@ -38,5 +39,4 @@ LabelLink.propTypes = {
   labelClick: PropTypes.func,
   icon: PropTypes.node,
   label: PropTypes.string,
-  blueLabel: PropTypes.string,
 };

--- a/breaking-front/src/components/Toggle/Toggle.stories.js
+++ b/breaking-front/src/components/Toggle/Toggle.stories.js
@@ -4,7 +4,6 @@ import { ReactComponent as MoneyIcon } from 'assets/svg/money.svg';
 import { ReactComponent as SettingIcon } from 'assets/svg/setting.svg';
 import { ReactComponent as MyPageIcon } from 'assets/svg/mypage.svg';
 import Line from 'components/Line/Line';
-import { PAGE_PATH } from 'constants/path';
 import styled from 'styled-components';
 
 export default {
@@ -39,21 +38,12 @@ ProfileToggle.args = {
   children: (
     <>
       <Toggle.LabelLink
-        path={PAGE_PATH.TRANSACTION}
         icon={<MoneyIcon />}
         label="10,000원"
         blueLabel="입출금내역"
       />
-      <Toggle.LabelLink
-        path={PAGE_PATH.MYPAGE}
-        icon={<MyPageIcon />}
-        label="마이페이지"
-      />
-      <Toggle.LabelLink
-        path={PAGE_PATH.PROFILE_EDIT}
-        icon={<SettingIcon />}
-        label="프로필 수정"
-      />
+      <Toggle.LabelLink icon={<MyPageIcon />} label="마이페이지" />
+      <Toggle.LabelLink icon={<SettingIcon />} label="프로필 수정" />
       <Line width="200" />
       <Logout>로그아웃</Logout>
     </>
@@ -64,21 +54,9 @@ export const NarrowToggle = Template.bind({});
 NarrowToggle.args = {
   children: (
     <>
-      <Toggle.LabelLink
-        path={PAGE_PATH.TRANSACTION}
-        icon={<MoneyIcon />}
-        label="수정"
-      />
-      <Toggle.LabelLink
-        path={PAGE_PATH.MYPAGE}
-        icon={<MyPageIcon />}
-        label="삭제"
-      />
-      <Toggle.LabelLink
-        path={PAGE_PATH.PROFILE_EDIT}
-        icon={<SettingIcon />}
-        label="공유"
-      />
+      <Toggle.LabelLink icon={<MoneyIcon />} label="수정" />
+      <Toggle.LabelLink icon={<MyPageIcon />} label="삭제" />
+      <Toggle.LabelLink icon={<SettingIcon />} label="공유" />
     </>
   ),
 };

--- a/breaking-front/src/components/Toggle/Toggle.styles.js
+++ b/breaking-front/src/components/Toggle/Toggle.styles.js
@@ -1,4 +1,3 @@
-import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 export const ToggleContainer = styled.div`
@@ -31,7 +30,7 @@ export const Toggle = styled.div`
   background-color: ${({ theme }) => theme.white};
 `;
 
-export const LabelLink = styled(Link)`
+export const LabelLink = styled.label`
   margin-bottom: 10px;
   display: flex;
   align-items: center;

--- a/breaking-front/src/components/Toggle/Toggle.styles.js
+++ b/breaking-front/src/components/Toggle/Toggle.styles.js
@@ -30,22 +30,17 @@ export const Toggle = styled.div`
   background-color: ${({ theme }) => theme.white};
 `;
 
-export const LabelLink = styled.label`
+export const LabelLink = styled.div`
+  display: flex;
   margin-bottom: 10px;
+`;
+
+export const Label = styled.label`
   display: flex;
   align-items: center;
 `;
 
-export const LabelText = styled.label`
+export const LabelText = styled.span`
   margin-left: 5px;
-  cursor: pointer;
-`;
-
-export const BlueLabel = styled.span`
-  position: absolute;
-  right: 20px;
-  font-size: 12px;
-  color: ${({ theme }) => theme.blue[900]};
-  font-weight: 600;
   cursor: pointer;
 `;

--- a/breaking-front/src/hooks/queries/usePostReply.js
+++ b/breaking-front/src/hooks/queries/usePostReply.js
@@ -3,7 +3,7 @@ import { useInfiniteQuery } from 'react-query';
 
 const usePostReply = (commentId) => {
   return useInfiniteQuery(['postReply', commentId], getPostReplyData, {
-    enabled: false,
+    enabled: !!commentId,
 
     getNextPageParam: (lastPage) => {
       return lastPage.cursor;

--- a/breaking-front/src/mocks/dummyData/contents.js
+++ b/breaking-front/src/mocks/dummyData/contents.js
@@ -137,78 +137,74 @@ export const POST_DATA = {
   commentCount: 5,
 };
 
-export const COMMENT_DATA = {
-  comment: [
-    {
-      commentId: 1,
-      content:
-        '킹받네\n#공감 #추천 #해#시#태#그 글 사이에#해시태그 있어도 잘 됩니다!',
-      likeCount: 1,
-      replyCount: 2,
-      user: {
-        userId: NO_STATUSMSG_USER.userId,
-        profileImgURL: NO_STATUSMSG_USER.profileImgURL,
-        nickname: NO_STATUSMSG_USER.nickname,
-      },
-      isLiked: false,
-      createdTime: '2022-07-25T15:32:39.445Z',
+export const COMMENT_DATA = [
+  {
+    commentId: 1,
+    content:
+      '킹받네\n#공감 #추천 #해#시#태#그 글 사이에#해시태그 있어도 잘 됩니다!',
+    likeCount: 1,
+    replyCount: 2,
+    user: {
+      userId: NO_STATUSMSG_USER.userId,
+      profileImgURL: NO_STATUSMSG_USER.profileImgURL,
+      nickname: NO_STATUSMSG_USER.nickname,
     },
-    {
-      commentId: 2,
-      content: '유익한 정보 감사합니다!',
-      likeCount: 129,
-      replyCount: 0,
-      user: {
-        userId: NO_PROFILEIMGURL_USER.userId,
-        profileImgURL: NO_PROFILEIMGURL_USER.profileImgURL,
-        nickname: NO_PROFILEIMGURL_USER.nickname,
-      },
-      isLiked: false,
-      createdTime: '2022-07-25T15:32:39.445Z',
+    isLiked: false,
+    createdTime: '2022-07-25T15:32:39.445Z',
+  },
+  {
+    commentId: 2,
+    content: '유익한 정보 감사합니다!',
+    likeCount: 129,
+    replyCount: 0,
+    user: {
+      userId: NO_PROFILEIMGURL_USER.userId,
+      profileImgURL: NO_PROFILEIMGURL_USER.profileImgURL,
+      nickname: NO_PROFILEIMGURL_USER.nickname,
     },
-    {
-      commentId: 5,
-      content: '이거 띄어쓰기\n한건데 잘 되나요?\n#띄어쓰기 #잘됨?',
-      likeCount: 991199,
-      replyCount: 0,
-      user: {
-        userId: NORMAL_USER.userId,
-        profileImgURL: NORMAL_USER.profileImgURL,
-        nickname: NORMAL_USER.nickname,
-      },
-      isLiked: true,
-      createdTime: '2022-07-25T15:32:39.445Z',
+    isLiked: false,
+    createdTime: '2022-07-25T15:32:39.445Z',
+  },
+  {
+    commentId: 5,
+    content: '이거 띄어쓰기\n한건데 잘 되나요?\n#띄어쓰기 #잘됨?',
+    likeCount: 991199,
+    replyCount: 0,
+    user: {
+      userId: NORMAL_USER.userId,
+      profileImgURL: NORMAL_USER.profileImgURL,
+      nickname: NORMAL_USER.nickname,
     },
-  ],
-};
+    isLiked: true,
+    createdTime: '2022-07-25T15:32:39.445Z',
+  },
+];
 
-export const REPLY_DATA = {
-  comment: [
-    {
-      commentId: 3,
-      content: '공감합니다',
-      likeCount: 1,
-      replyCount: 0,
-      user: {
-        userId: NO_POSTCOUNT_USER.userId,
-        profileImgURL: NO_POSTCOUNT_USER.profileImgURL,
-        nickname: NO_POSTCOUNT_USER.nickname,
-      },
-      isLiked: false,
-      createdTime: '2022-07-25T15:32:39.445Z',
+export const REPLY_DATA = [
+  {
+    commentId: 3,
+    content: '공감합니다',
+    likeCount: 1,
+    replyCount: 0,
+    user: {
+      userId: NO_POSTCOUNT_USER.userId,
+      profileImgURL: NO_POSTCOUNT_USER.profileImgURL,
+      nickname: NO_POSTCOUNT_USER.nickname,
     },
-    {
-      commentId: 4,
-      content: '저두요',
-      likeCount: 1,
-      replyCount: 0,
-      user: {
-        userId: NO_FOLLOW_USER.userId,
-        profileImgURL: NO_FOLLOW_USER.profileImgURL,
-        nickname: NO_FOLLOW_USER.nickname,
-      },
-      isLiked: false,
-      createdTime: '2022-07-25T15:32:39.445Z',
+    isLiked: false,
+    createdTime: '2022-07-25T15:32:39.445Z',
+  },
+  {
+    commentId: 4,
+    content: '저두요',
+    likeCount: 1,
+    replyCount: 0,
+    user: {
+      userId: NO_FOLLOW_USER.userId,
+      profileImgURL: NO_FOLLOW_USER.profileImgURL,
+      nickname: NO_FOLLOW_USER.nickname,
     },
-  ],
-};
+    isLiked: false,
+    createdTime: '2022-07-25T15:32:39.445Z',
+  },
+];

--- a/breaking-front/src/mocks/postHandlers.js
+++ b/breaking-front/src/mocks/postHandlers.js
@@ -31,7 +31,7 @@ export const postHandlers = [
   }),
 
   rest.get(API_PATH.POST_BOUGHT_LIST(':postId'), (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json({ Users: boughtUserList }));
+    return res(ctx.status(200), ctx.json(boughtUserList));
   }),
 
   rest.delete(API_PATH.POST_DELETE(':postId'), (req, res, ctx) => {

--- a/breaking-front/src/pages/Post/Post.js
+++ b/breaking-front/src/pages/Post/Post.js
@@ -59,6 +59,7 @@ const Post = () => {
     data: postCommentData,
     isFetching: isPostCommentFetching,
     fetchNextPage: FetchNextPostComment,
+    hasNextPage: postCommentHasNextPage,
   } = usePostComment(postId);
 
   const { mutate: PostLike } = useMutation(postPostLike);
@@ -139,20 +140,19 @@ const Post = () => {
         observer.observe(entry.target);
       }
     };
-
-    if (postCommentData) {
+    if (postCommentHasNextPage && !isPostCommentFetching) {
       observer = new IntersectionObserver(onIntersect, {
         threshold: 0.8,
       });
       observer.observe(targetRef.current);
     }
     return () => observer && observer.disconnect();
-  }, [FetchNextPostComment, postCommentData]);
+  }, [FetchNextPostComment, isPostCommentFetching, postCommentHasNextPage]);
 
   return (
     <>
       <Modal isOpen={isModalOpen} closeClick={toggleModal} title="구매자 목록">
-        {PostBoughtList?.data.Users.map((item) => (
+        {PostBoughtList?.data.map((item) => (
           <FollowCard
             cardClick={() => navigate(PAGE_PATH.PROFILE(item.userId))}
             profileData={item}

--- a/breaking-front/src/pages/Post/Post.js
+++ b/breaking-front/src/pages/Post/Post.js
@@ -83,7 +83,7 @@ const Post = () => {
       DeletePost(postId, {
         onSuccess: () => {
           alert('게시글을 삭제하였습니다.');
-          navigate(PAGE_PATH.HOME);
+          navigate(-1);
         },
       });
   };
@@ -100,6 +100,7 @@ const Post = () => {
       PostBuy(postId, {
         onSuccess: () => {
           alert('게시글을 구매하였습니다.');
+          // 새로 postData 불러오기
         },
       });
   };
@@ -256,43 +257,35 @@ const Post = () => {
                 {PostData?.data.commentCount.toLocaleString('ko-KR')}
               </label>
             </Style.ContentStatus>
-            <ETCIcon onClick={toggleComment} />
-            <Style.ContentToggle>
+            <ETCIcon
+              onClick={toggleComment}
+              tabIndex="0"
+              onBlur={() => setIsContentToggle(false)}
+            />
+            <Style.ContentToggle
+              onMouseDown={(event) => event.preventDefault()}
+            >
               {isContentToggle && (
                 <Toggle width="100px">
                   {PostData?.data.user.userId === userId ? (
                     <>
+                      <Toggle.LabelLink icon={<EditIcon />} label="수정" />
                       <Toggle.LabelLink
-                        path={PAGE_PATH.POST(postId)}
-                        icon={<EditIcon />}
-                        label="수정"
-                      />
-                      <Toggle.LabelLink
-                        path={PAGE_PATH.POST(postId)}
                         icon={<RemoveIcon />}
                         label="삭제"
-                        onClick={postDeleteClick}
+                        labelClick={postDeleteClick}
                       />
                     </>
                   ) : (
-                    <Toggle.LabelLink
-                      path={PAGE_PATH.POST(postId)}
-                      icon={<HideIcon />}
-                      label="숨김"
-                    />
+                    <Toggle.LabelLink icon={<HideIcon />} label="숨김" />
                   )}
 
                   <Toggle.LabelLink
-                    path={PAGE_PATH.POST(postId)}
                     icon={isBookmarked ? <BookmarkedIcon /> : <BookmarkIcon />}
                     label="북마크"
-                    onClick={toggleBookmarked}
+                    labelClick={toggleBookmarked}
                   />
-                  <Toggle.LabelLink
-                    path={PAGE_PATH.POST(postId)}
-                    icon={<ShareIcon />}
-                    label="공유"
-                  />
+                  <Toggle.LabelLink icon={<ShareIcon />} label="공유" />
                 </Toggle>
               )}
             </Style.ContentToggle>

--- a/breaking-front/src/pages/Post/Post.js
+++ b/breaking-front/src/pages/Post/Post.js
@@ -124,6 +124,7 @@ const Post = () => {
     if (PostData?.data.user.userId === userId) setPurchaseType('구매자 목록');
     else if (PostData?.data.isPurchased) setPurchaseType('구매 완료');
     else setPurchaseType('구매 하기');
+
     setIsBookmarked(PostData?.data.isBookmarked);
     setIsLiked(PostData?.data.isLiked);
     setLikeCount(PostData?.data.likeCount);

--- a/breaking-front/src/pages/Post/Post.js
+++ b/breaking-front/src/pages/Post/Post.js
@@ -311,11 +311,11 @@ const Post = () => {
               />
             ))
           )}
-          <div ref={targetRef}>
+          <Style.TargetDiv ref={targetRef}>
             {isPostCommentFetching && (
               <Style.Loading type="spin" color={theme.blue[900]} width="40px" />
             )}
-          </div>
+          </Style.TargetDiv>
         </Style.Comments>
       </Style.Post>
     </>

--- a/breaking-front/src/pages/Post/Post.styles.js
+++ b/breaking-front/src/pages/Post/Post.styles.js
@@ -2,7 +2,6 @@ import ReactLoading from 'react-loading';
 import styled from 'styled-components';
 
 export const Post = styled.div`
-  position: relative;
   width: 800px;
   margin: 0 auto;
   padding-top: 40px;
@@ -118,6 +117,11 @@ export const ContentToggle = styled.div`
 export const Comments = styled.div`
   width: 800px;
   margin-bottom: 30px;
+`;
+
+export const TargetDiv = styled.div`
+  position: relative;
+  height: 140px;
 `;
 
 export const Loading = styled(ReactLoading)`

--- a/breaking-front/src/pages/Post/Post.styles.js
+++ b/breaking-front/src/pages/Post/Post.styles.js
@@ -91,6 +91,7 @@ export const ContentFooter = styled.div`
   margin-top: 20px;
   justify-content: space-between;
   svg {
+    outline: none;
     cursor: pointer;
   }
 `;

--- a/breaking-front/src/pages/Post/units/Carousel.styles.js
+++ b/breaking-front/src/pages/Post/units/Carousel.styles.js
@@ -5,7 +5,7 @@ export const CarouselContainer = styled.div`
   width: 800px;
   height: 400px;
   border-radius: 10px;
-  background-color: black;
+  background-color: ${({ theme }) => theme.black};
   overflow: hidden;
 `;
 

--- a/breaking-front/src/pages/Post/units/Comment.js
+++ b/breaking-front/src/pages/Post/units/Comment.js
@@ -75,10 +75,13 @@ const Comment = ({ comment, type, postId }) => {
   };
 
   const toggleLiked = () => {
-    isLiked
-      ? DeleteCommentLike(comment.commentId)
-      : CommentLike(comment.commentId);
-    setLikeCount((pre) => (isLiked ? pre - 1 : pre + 1));
+    if (isLiked) {
+      DeleteCommentLike(comment.commentId);
+      setLikeCount((pre) => pre - 1);
+    } else {
+      CommentLike(comment.commentId);
+      setLikeCount((pre) => pre + 1);
+    }
     setIsLiked((pre) => !pre);
   };
 

--- a/breaking-front/src/pages/Post/units/Comment.js
+++ b/breaking-front/src/pages/Post/units/Comment.js
@@ -43,6 +43,7 @@ const Comment = ({ comment, type }) => {
     data: postReplyData,
     isFetching: isPostReplyFetching,
     fetchNextPage: FetchNextPostReply,
+    hasNextPage: postReplyHasNextPage,
   } = usePostReply(commentId);
 
   const { mutate: CommentLike } = useMutation(postPostCommentLike);
@@ -190,20 +191,21 @@ const Comment = ({ comment, type }) => {
       )}
       {isOpenReplyToggle && (
         <Style.Reply>
-          {isPostReplyFetching ? (
-            <Style.Loading type="spin" color={theme.blue[900]} width="40px" />
-          ) : (
-            <>
-              {postReplyData?.pages.map((page) =>
-                page.result.map((reply) => (
-                  <Comment comment={reply} type="reply" key={reply.commentId} />
-                ))
-              )}
-              <Style.MoreChowReply onClick={moreShowReplyClick}>
-                <MoreIcon />
-                더보기
-              </Style.MoreChowReply>
-            </>
+          {postReplyData?.pages.map((page) =>
+            page.result.map((reply) => (
+              <Comment comment={reply} type="reply" key={reply.commentId} />
+            ))
+          )}
+          {postReplyHasNextPage && !isPostReplyFetching && (
+            <Style.MoreChowReply onClick={moreShowReplyClick}>
+              <MoreIcon />
+              더보기
+            </Style.MoreChowReply>
+          )}
+          {isPostReplyFetching && (
+            <Style.LoadingContainer>
+              <Style.Loading type="spin" color={theme.blue[900]} width="40px" />
+            </Style.LoadingContainer>
           )}
         </Style.Reply>
       )}

--- a/breaking-front/src/pages/Post/units/Comment.js
+++ b/breaking-front/src/pages/Post/units/Comment.js
@@ -26,7 +26,7 @@ import { ReactComponent as DropDownIcon } from 'assets/svg/drop_down.svg';
 import { ReactComponent as MoreIcon } from 'assets/svg/more_arrow.svg';
 import { useTheme } from 'styled-components';
 
-const Comment = ({ comment, type, postId }) => {
+const Comment = ({ comment, type }) => {
   const theme = useTheme();
   const navigate = useNavigate();
 
@@ -37,13 +37,13 @@ const Comment = ({ comment, type, postId }) => {
   const [isOpenReplyToggle, setIsOpenReplyToggle] = useState(false);
   const [isLiked, setIsLiked] = useState(comment.isLiked);
   const [likeCount, setLikeCount] = useState(comment.likeCount);
+  const [commentId, setCommentId] = useState('');
 
   const {
     data: postReplyData,
     isFetching: isPostReplyFetching,
     fetchNextPage: FetchNextPostReply,
-    refetch: PostReplyReFetch,
-  } = usePostReply(comment.commentId);
+  } = usePostReply(commentId);
 
   const { mutate: CommentLike } = useMutation(postPostCommentLike);
   const { mutate: DeleteCommentLike } = useMutation(deletePostCommentLike);
@@ -95,7 +95,7 @@ const Comment = ({ comment, type, postId }) => {
 
   const toggleReply = () => {
     setIsOpenReplyToggle((pre) => !pre);
-    PostReplyReFetch();
+    setCommentId(comment.commentId);
   };
 
   return (
@@ -225,7 +225,6 @@ const Comment = ({ comment, type, postId }) => {
 Comment.propTypes = {
   comment: PropTypes.object.isRequired,
   type: PropTypes.oneOf(['comment', 'reply']),
-  postId: PropTypes.number,
 };
 
 export default Comment;

--- a/breaking-front/src/pages/Post/units/Comment.js
+++ b/breaking-front/src/pages/Post/units/Comment.js
@@ -136,37 +136,34 @@ const Comment = ({ comment, type, postId }) => {
                 <span onClick={toggleCommentForm}>답글쓰기</span>
               )}
             </Style.Status>
-            <Style.ETCIconContainer onClick={toggleComment}>
+            <Style.ETCIconContainer
+              onClick={toggleComment}
+              tabIndex="0"
+              onBlur={() => setIsOpenCommentToggle(false)}
+            >
               <ETCIcon />
             </Style.ETCIconContainer>
-            <Style.CommentToggle isOpen={isOpenCommentToggle}>
+            <Style.CommentToggle
+              isOpen={isOpenCommentToggle}
+              onMouseDown={(event) => event.preventDefault()}
+            >
               {comment.user.userId === userId ? (
                 <Toggle width="100px">
                   <Toggle.LabelLink
-                    path={PAGE_PATH.POST(postId)}
                     icon={<EditIcon />}
                     label="수정"
-                    onClick={commentEditClick}
+                    labelClick={commentEditClick}
                   />
                   <Toggle.LabelLink
-                    path={PAGE_PATH.POST(postId)}
                     icon={<RemoveIcon />}
                     label="삭제"
-                    onClick={commentDeleteClick}
+                    labelClick={commentDeleteClick}
                   />
                 </Toggle>
               ) : (
                 <Toggle width="100px">
-                  <Toggle.LabelLink
-                    path={PAGE_PATH.POST(postId)}
-                    icon={<ChatIcon />}
-                    label="채팅"
-                  />
-                  <Toggle.LabelLink
-                    path={PAGE_PATH.POST(postId)}
-                    icon={<BlockIcon />}
-                    label="차단"
-                  />
+                  <Toggle.LabelLink icon={<ChatIcon />} label="채팅" />
+                  <Toggle.LabelLink icon={<BlockIcon />} label="차단" />
                 </Toggle>
               )}
             </Style.CommentToggle>

--- a/breaking-front/src/pages/Post/units/Comment.styles.js
+++ b/breaking-front/src/pages/Post/units/Comment.styles.js
@@ -98,6 +98,11 @@ export const ReplyCount = styled.div`
   }
 `;
 
+export const LoadingContainer = styled.div`
+  position: relative;
+  height: 100px;
+`;
+
 export const Loading = styled(ReactLoading)`
   position: absolute;
   left: 50%;
@@ -106,7 +111,6 @@ export const Loading = styled(ReactLoading)`
 `;
 
 export const Reply = styled.div`
-  position: relative;
   margin-left: auto;
   min-height: 100px;
   width: 750px;

--- a/breaking-front/src/pages/Post/units/CommentForm.js
+++ b/breaking-front/src/pages/Post/units/CommentForm.js
@@ -23,20 +23,20 @@ const CommentForm = ({
 
   const { mutate: CommentWrite } = useMutation(postPostCommentWrite, {
     onSuccess: () => {
-      queryClient.invalidateQueries(['postComment']);
+      queryClient.resetQueries('postComment');
     },
   });
 
   const { mutate: CommentReply } = useMutation(postPostReplyWrite, {
     onSuccess: () => {
-      queryClient.invalidateQueries(['postReply', commentId]);
+      queryClient.resetQueries(['postReply', commentId]);
     },
   });
 
   const { mutate: CommentEdit } = useMutation(putPostCommentEdit, {
     onSuccess: () => {
-      queryClient.invalidateQueries(['postComment']);
-      queryClient.invalidateQueries(['postReply']);
+      queryClient.resetQueries('postComment');
+      queryClient.resetQueries('postReply');
     },
   });
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
#83

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
- Feed 컴포넌트에 viewCount(조회수)가 추가되었습니다. 그리고 가격의 위치와 크기를 변경하여 직관적으로 보이도록 수정하였습니다. 좋아요 및 북마크, Feed 삭제 로직이 추가되었습니다. Feed 삭제 시 `display: none;`으로 설정하여 UI에서 안보이도록 설정했습니다.
- Toggle의 서브 컴포넌트인 LabelLink의 태그를 Link로 했을 때 path가 필수적으로 들어가야했고, 아이콘 및 글자 옆을 클릭해도 onClick 이벤트가 작동하는 문제를 해결하였습니다. 그리고 blueLabel prop을 제거하고 이것이 필요한 Header에서 따로 blueLabel styled component를 생성하였습니다.
- Header 컴포넌트에서 토글이 정상적으로 작동하지 않는 문제를 해결하였습니다.
- Header 컴포넌트가 스토리북에서 오류가 뜨는 문제가 있었습니다. useContext 부분을 가져오지 못해서 발생한 문제인데, 스토리북에 msw addon을 사용하여 해결하려했지만 정상적으로 모킹이 되지 않아 useContext 부분을 Layout에서 불러온 후 props로 데이터를 가져오도록 수정하였습니다.
- Post 페이지에서 토글이 열린 상태에서 다른 곳을 클릭했을 때 토글이 닫히도록 수정하였습니다.
- Post 페이지에서 댓글이 더 있는 경우에만 인피니티 스크롤링이 작동하도록 설정하였습니다. 그리고 대댓글은 더 불러올 데이터가 없을 시 더보기 버튼이 사라지도록 구현하였습니다.
- 댓글 등록 및 수정 시 resetQueries 메소드를 사용하여 데이터를 다시 불러오도록 하였습니다.
- 
## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/23312485/182067635-d0c73272-b1b5-459d-9c87-1713574cd580.png)


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
