### PR TITLE
feat: post write 페이지 카카오맵, 동영상/이미지 업로드 기능추가

### DIFF
--- a/breaking-front/package-lock.json
+++ b/breaking-front/package-lock.json
@@ -15,6 +15,7 @@
         "react": "^18.2.0",
         "react-datepicker": "^4.8.0",
         "react-dom": "^18.2.0",
+        "react-kakao-maps-sdk": "^1.1.1",
         "react-loading": "^2.0.3",
         "react-query": "^3.39.1",
         "react-router-dom": "^6.3.0",
@@ -22600,6 +22601,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/kakao.maps.d.ts": {
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.32.tgz",
+      "integrity": "sha512-xQULJE5XDOjfeK4Ba04AH4l/raTvHEoX72cbBhCUp6nS9rpJ7tEQgJP2A68kwTesnK5ug0Pa9LVEp+HfYHBsrg=="
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -27153,6 +27159,18 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-kakao-maps-sdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.1.tgz",
+      "integrity": "sha512-x7UEBC0qedBZOBJvCXUoxT4p6iH4t4lj8MKgo2QwGPJUsTi4njbhWDY2HYlNty7a42q1kL8gzeYouJjbg1ylAA==",
+      "dependencies": {
+        "kakao.maps.d.ts": "^0.1.32"
+      },
+      "peerDependencies": {
+        "react": "^17.0.2",
+        "react-dom": "^17.0.2"
+      }
     },
     "node_modules/react-loading": {
       "version": "2.0.3",
@@ -49681,6 +49699,11 @@
       "integrity": "sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==",
       "dev": true
     },
+    "kakao.maps.d.ts": {
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/kakao.maps.d.ts/-/kakao.maps.d.ts-0.1.32.tgz",
+      "integrity": "sha512-xQULJE5XDOjfeK4Ba04AH4l/raTvHEoX72cbBhCUp6nS9rpJ7tEQgJP2A68kwTesnK5ug0Pa9LVEp+HfYHBsrg=="
+    },
     "kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -52977,6 +53000,14 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "react-kakao-maps-sdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-kakao-maps-sdk/-/react-kakao-maps-sdk-1.1.1.tgz",
+      "integrity": "sha512-x7UEBC0qedBZOBJvCXUoxT4p6iH4t4lj8MKgo2QwGPJUsTi4njbhWDY2HYlNty7a42q1kL8gzeYouJjbg1ylAA==",
+      "requires": {
+        "kakao.maps.d.ts": "^0.1.32"
+      }
     },
     "react-loading": {
       "version": "2.0.3",

--- a/breaking-front/package.json
+++ b/breaking-front/package.json
@@ -10,6 +10,7 @@
     "react": "^18.2.0",
     "react-datepicker": "^4.8.0",
     "react-dom": "^18.2.0",
+    "react-kakao-maps-sdk": "^1.1.1",
     "react-loading": "^2.0.3",
     "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",

--- a/breaking-front/public/index.html
+++ b/breaking-front/public/index.html
@@ -26,6 +26,8 @@
     -->
     <title>React App</title>
     <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
+    <script type="text/javascript" src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_JAVASCRIPT_KEY%&libraries=services,clusterer"
+></script>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/breaking-front/src/constants/palette.js
+++ b/breaking-front/src/constants/palette.js
@@ -27,6 +27,7 @@ const PALETTE = {
   WHITE: '#FFFFFF',
   BLACK: '#000000',
   OPACITY_BLACK: 'rgba(0, 0, 0, 0.4)',
+  OPACITY_WHITE: 'rgba(256, 256, 256, 0.8)',
 };
 
 export default PALETTE;

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -3,7 +3,7 @@ import * as Style from 'pages/PostWrite/PostWrite.styles';
 import PostUploadMediaForm from 'pages/PostWrite/units/PostWriteUploadMediaForm';
 import 'react-datepicker/dist/react-datepicker.css';
 import dayjs from 'dayjs';
-import PostWriteSearchLocation from './units/PostWriteSearchLocation';
+import PostWriteSearchLocation from 'pages/PostWrite/units/PostWriteSearchLocation';
 
 const PostWrite = () => {
   const [occurDate, setOccurDate] = useState(dayjs().format('YYYY-MM-DD'));

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -1,12 +1,9 @@
 import React, { useState } from 'react';
 import * as Style from 'pages/PostWrite/PostWrite.styles';
 import PostUploadMediaForm from 'pages/PostWrite/units/PostWriteUploadMediaForm';
-import { ReactComponent as LocationIcon } from 'assets/svg/location.svg';
 import 'react-datepicker/dist/react-datepicker.css';
 import dayjs from 'dayjs';
-import Modal from 'components/Modal/Modal';
-import { Map } from 'react-kakao-maps-sdk';
-import { useEffect } from 'react';
+import PostWriteSearchLocation from './units/PostWriteSearchLocation';
 
 const PostWrite = () => {
   const [occurDate, setOccurDate] = useState(dayjs().format('YYYY-MM-DD'));
@@ -15,10 +12,6 @@ const PostWrite = () => {
   const [selectedAnonymous, setSelectedAnonymous] = useState('public');
   const [price, setPrice] = useState(0);
   const [isShowPriceInput, setIsShowPriceInput] = useState(false);
-  const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const [map, setMap] = useState();
-  console.log(map);
 
   const handlePostType = (event) => {
     setSelectedPostType(event.target.id);
@@ -40,9 +33,6 @@ const PostWrite = () => {
   const toggleShowPirceInput = () => {
     setIsShowPriceInput((pre) => !pre);
   };
-  const toggleModal = () => {
-    setIsModalOpen((pre) => !pre);
-  };
 
   const maxLengthCheck = ({ target }) => {
     if (target.value.length > target.maxLength) {
@@ -50,13 +40,9 @@ const PostWrite = () => {
     }
   };
 
-  useEffect(() => {
-    isModalOpen && map.relayout();
-  }, [isModalOpen]);
   return (
     <Style.Container>
       <PostUploadMediaForm />
-
       <Style.OccurTimeLayout>
         <Style.PostWriteTitle>제보 발생 시간</Style.PostWriteTitle>
         <Style.DatePicker
@@ -72,38 +58,8 @@ const PostWrite = () => {
       </Style.OccurTimeLayout>
 
       <Style.LocationLayout>
-        <Style.PostWriteTitle>
-          위치
-          <Style.FindLocationLayout>
-            <LocationIcon />
-            <Style.FindLocationMessage>
-              현재 위치 찾기
-            </Style.FindLocationMessage>
-          </Style.FindLocationLayout>
-        </Style.PostWriteTitle>
-
-        <Style.LocationInput
-          type="text"
-          placeholder="주소를 입력하세요"
-          onClick={toggleModal}
-        />
+        <PostWriteSearchLocation />
       </Style.LocationLayout>
-      <Modal title="위치 찾기" isOpen={isModalOpen} closeClick={toggleModal}>
-        <Map
-          center={{
-            // 지도의 중심좌표
-            lat: 33.450701,
-            lng: 126.570667,
-          }}
-          style={{
-            // 지도의 크기
-            width: '100%',
-            height: '450px',
-          }}
-          level={3} // 지도의 확대 레벨
-          onCreate={setMap}
-        ></Map>
-      </Modal>
 
       <Style.ContextLayout>
         <Style.ContextTitleInput

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -4,6 +4,9 @@ import PostUploadMediaForm from 'pages/PostWrite/units/PostWriteUploadMediaForm'
 import { ReactComponent as LocationIcon } from 'assets/svg/location.svg';
 import 'react-datepicker/dist/react-datepicker.css';
 import dayjs from 'dayjs';
+import Modal from 'components/Modal/Modal';
+import { Map } from 'react-kakao-maps-sdk';
+import { useEffect } from 'react';
 
 const PostWrite = () => {
   const [occurDate, setOccurDate] = useState(dayjs().format('YYYY-MM-DD'));
@@ -12,6 +15,10 @@ const PostWrite = () => {
   const [selectedAnonymous, setSelectedAnonymous] = useState('public');
   const [price, setPrice] = useState(0);
   const [isShowPriceInput, setIsShowPriceInput] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const [map, setMap] = useState();
+  console.log(map);
 
   const handlePostType = (event) => {
     setSelectedPostType(event.target.id);
@@ -33,6 +40,9 @@ const PostWrite = () => {
   const toggleShowPirceInput = () => {
     setIsShowPriceInput((pre) => !pre);
   };
+  const toggleModal = () => {
+    setIsModalOpen((pre) => !pre);
+  };
 
   const maxLengthCheck = ({ target }) => {
     if (target.value.length > target.maxLength) {
@@ -40,6 +50,9 @@ const PostWrite = () => {
     }
   };
 
+  useEffect(() => {
+    isModalOpen && map.relayout();
+  }, [isModalOpen]);
   return (
     <Style.Container>
       <PostUploadMediaForm />
@@ -69,8 +82,28 @@ const PostWrite = () => {
           </Style.FindLocationLayout>
         </Style.PostWriteTitle>
 
-        <Style.LocationInput type="text" placeholder="주소를 입력하세요" />
+        <Style.LocationInput
+          type="text"
+          placeholder="주소를 입력하세요"
+          onClick={toggleModal}
+        />
       </Style.LocationLayout>
+      <Modal title="위치 찾기" isOpen={isModalOpen} closeClick={toggleModal}>
+        <Map
+          center={{
+            // 지도의 중심좌표
+            lat: 33.450701,
+            lng: 126.570667,
+          }}
+          style={{
+            // 지도의 크기
+            width: '100%',
+            height: '450px',
+          }}
+          level={3} // 지도의 확대 레벨
+          onCreate={setMap}
+        ></Map>
+      </Modal>
 
       <Style.ContextLayout>
         <Style.ContextTitleInput

--- a/breaking-front/src/pages/PostWrite/PostWrite.styles.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.styles.js
@@ -54,34 +54,6 @@ export const LocationLayout = styled.div`
   margin-top: 60px;
 `;
 
-export const FindLocationLayout = styled.div`
-  display: inline-block;
-  margin-left: 10px;
-  cursor: pointer;
-  > svg {
-    width: 15px;
-    height: 15px;
-    vertical-align: middle;
-    > path {
-      stroke: ${({ theme }) => theme.blue[900]};
-    }
-  }
-`;
-
-export const FindLocationMessage = styled.span`
-  font-size: 14px;
-  color: ${({ theme }) => theme.blue[900]};
-  vertical-align: middle;
-`;
-
-export const LocationInput = styled.input`
-  width: 410px;
-  padding: 10px;
-  margin-top: 20px;
-  border: solid 1px ${({ theme }) => theme.gray[500]};
-  border-radius: 10px;
-`;
-
 export const ContextLayout = styled.div`
   margin-top: 80px;
   margin-bottom: 40px;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteModal.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteModal.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as Style from 'pages/PostWrite/units/PostWriteModal.styles';
+import { ReactComponent as CloseIcon } from 'assets/svg/x_mark.svg';
+// import { ReactComponent as HambugerIcon } from 'assets/svg/hambuger-menu.svg';
+
+const PostWriteModal = ({ isOpen, children }) => {
+  return (
+    <Style.ModalOverlay isOpen={isOpen}>
+      <Style.Modal>
+        <Style.CloseButton>
+          <CloseIcon />
+        </Style.CloseButton>
+        <Style.Content>{children}</Style.Content>
+      </Style.Modal>
+    </Style.ModalOverlay>
+  );
+};
+
+PostWriteModal.propTypes = {
+  isOpen: PropTypes.bool,
+  closeClick: PropTypes.func,
+  title: PropTypes.string,
+  children: PropTypes.node,
+};
+
+export default PostWriteModal;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteModal.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteModal.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import * as Style from 'pages/PostWrite/units/PostWriteModal.styles';
 import { ReactComponent as CloseIcon } from 'assets/svg/x_mark.svg';
-// import { ReactComponent as HambugerIcon } from 'assets/svg/hambuger-menu.svg';
 
 const PostWriteModal = ({ isOpen, closeClick, children }) => {
   return (

--- a/breaking-front/src/pages/PostWrite/units/PostWriteModal.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteModal.js
@@ -4,11 +4,11 @@ import * as Style from 'pages/PostWrite/units/PostWriteModal.styles';
 import { ReactComponent as CloseIcon } from 'assets/svg/x_mark.svg';
 // import { ReactComponent as HambugerIcon } from 'assets/svg/hambuger-menu.svg';
 
-const PostWriteModal = ({ isOpen, children }) => {
+const PostWriteModal = ({ isOpen, closeClick, children }) => {
   return (
     <Style.ModalOverlay isOpen={isOpen}>
       <Style.Modal>
-        <Style.CloseButton>
+        <Style.CloseButton onClick={closeClick}>
           <CloseIcon />
         </Style.CloseButton>
         <Style.Content>{children}</Style.Content>
@@ -20,7 +20,6 @@ const PostWriteModal = ({ isOpen, children }) => {
 PostWriteModal.propTypes = {
   isOpen: PropTypes.bool,
   closeClick: PropTypes.func,
-  title: PropTypes.string,
   children: PropTypes.node,
 };
 

--- a/breaking-front/src/pages/PostWrite/units/PostWriteModal.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteModal.styles.js
@@ -5,14 +5,12 @@ export const ModalOverlay = styled.div`
   position: fixed;
   top: 0;
   left: 0;
-  right: 0;
-  bottom: 0;
+  z-index: 110;
   width: 100%;
   height: 100%;
   background-color: ${({ theme }) => theme.opacityBlack};
   justify-content: center;
   align-items: center;
-  z-index: 110;
 `;
 
 export const Modal = styled.div`

--- a/breaking-front/src/pages/PostWrite/units/PostWriteModal.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteModal.styles.js
@@ -28,13 +28,6 @@ export const CloseButton = styled.span`
   cursor: pointer;
 `;
 
-export const HambugerButton = styled.span`
-  position: absolute;
-  top: 20px;
-  left: 20px;
-  cursor: pointer;
-`;
-
 export const Content = styled.div`
   margin-top: 60px;
 `;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteModal.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteModal.styles.js
@@ -1,0 +1,42 @@
+import styled from 'styled-components';
+
+export const ModalOverlay = styled.div`
+  display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  height: 100%;
+  background-color: ${({ theme }) => theme.opacityBlack};
+  justify-content: center;
+  align-items: center;
+  z-index: 110;
+`;
+
+export const Modal = styled.div`
+  position: relative;
+  width: 950px;
+  height: 700px;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.white};
+`;
+
+export const CloseButton = styled.span`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  cursor: pointer;
+`;
+
+export const HambugerButton = styled.span`
+  position: absolute;
+  top: 20px;
+  left: 20px;
+  cursor: pointer;
+`;
+
+export const Content = styled.div`
+  margin-top: 60px;
+`;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react';
+import { ReactComponent as LocationIcon } from 'assets/svg/location.svg';
+import * as Style from 'pages/PostWrite/units/PostWriteSearchLocation.styles';
+import { Map, MapMarker } from 'react-kakao-maps-sdk';
+import Modal from 'components/Modal/Modal';
+
+const PostWriteSearchLocation = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [map, setMap] = useState();
+  const [info, setInfo] = useState();
+  const [markers, setMarkers] = useState([]);
+  const [searchContent, setSearchContent] = useState('');
+
+  const toggleModal = () => {
+    setIsModalOpen((pre) => !pre);
+  };
+
+  const handleSearchInput = (event) => {
+    setSearchContent(event.target.value);
+  };
+
+  const SearchMap = (event) => {
+    event.preventDefault();
+
+    console.log(event.target);
+  };
+  console.log(markers);
+
+  useEffect(() => {
+    map && map.relayout();
+  }, [isModalOpen, map]);
+
+  useEffect(() => {
+    const { kakao } = window;
+    const ps = new kakao.maps.services.Places();
+
+    ps.keywordSearch(searchContent, (data, status) => {
+      if (status === kakao.maps.services.Status.OK) {
+        // 검색된 장소 위치를 기준으로 지도 범위를 재설정하기위해
+        // LatLngBounds 객체에 좌표를 추가합니다
+        const bounds = new kakao.maps.LatLngBounds();
+        let markers = [];
+
+        for (var i = 0; i < data.length; i++) {
+          // @ts-ignore
+          markers.push({
+            position: {
+              lat: data[i].y,
+              lng: data[i].x,
+            },
+            content: data[i].place_name,
+          });
+          // @ts-ignore
+          bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
+        }
+        setMarkers(markers);
+
+        // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
+        map.setBounds(bounds);
+      }
+    });
+  }, [searchContent]);
+
+  return (
+    <>
+      <Style.PostWriteTitle>
+        위치
+        <Style.FindLocationLayout>
+          <LocationIcon />
+          <Style.FindLocationMessage>현재 위치 찾기</Style.FindLocationMessage>
+        </Style.FindLocationLayout>
+      </Style.PostWriteTitle>
+
+      <Style.LocationInput
+        type="text"
+        placeholder="주소를 입력하세요"
+        onClick={toggleModal}
+      />
+      <Modal title="위치 찾기" isOpen={isModalOpen} closeClick={toggleModal}>
+        <Map
+          center={{
+            // 지도의 중심좌표
+            lat: 37.5666805,
+            lng: 126.9784147,
+          }}
+          style={{
+            // 지도의 크기
+            width: '100%',
+            height: '450px',
+          }}
+          level={8} // 지도의 확대 레벨
+          onCreate={setMap}
+        >
+          {markers.map((marker) => (
+            <MapMarker
+              key={`marker-${marker.content}-${marker.position.lat},${marker.position.lng}`}
+              position={marker.position}
+              onClick={() => setInfo(marker)}
+            >
+              {info && info.content === marker.content && (
+                <div style={{ color: '#000' }}>{marker.content}</div>
+              )}
+            </MapMarker>
+          ))}
+        </Map>
+        <form onSubmit={SearchMap}>
+          <input
+            onChange={handleSearchInput}
+            value={searchContent}
+            type="text"
+          ></input>
+          <input type="submit"></input>
+        </form>
+      </Modal>
+    </>
+  );
+};
+
+export default PostWriteSearchLocation;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
@@ -26,7 +26,7 @@ const PostWriteSearchLocation = ({ setForm }) => {
     lng: 126.97866358173395,
   });
 
-  const [markerInformation, setMarkerInformation] = useState(); // marker 클릭시 보여주는 정보객체
+  const [markerInformation, setMarkerInformation] = useState({}); // marker 클릭시 보여주는 정보객체
   /*
    {
     lat: "number"
@@ -45,28 +45,23 @@ const PostWriteSearchLocation = ({ setForm }) => {
   const { kakao } = window;
   const geocoder = new kakao.maps.services.Geocoder();
 
-  const coord2AddressCallback = (addresses, status) => {
-    if (status === 'OK') {
-      setMarkerInformation((pre) => ({
-        ...pre,
-        roadAddressName: addresses[0].road_address?.address_name,
-        addressName: addresses[0].address.address_name,
-      }));
-      setIsCustomMarker(true);
-    }
-  };
-
   const SetCustomMarker = (lat, lng) => {
     // 클릭위치에 마커가 찍어지도록 state를 변경
-    setMarkerInformation({
-      lat: lat,
-      lng: lng,
-    });
     setMapCenterPosition({
       lat: lat,
       lng: lng,
     });
-    geocoder.coord2Address(lng, lat, coord2AddressCallback);
+    geocoder.coord2Address(lng, lat, (addresses, status) => {
+      if (status === 'OK') {
+        setMarkerInformation({
+          lat: lat,
+          lng: lng,
+          roadAddressName: addresses[0].road_address?.address_name,
+          addressName: addresses[0].address.address_name,
+        });
+        setIsCustomMarker(true);
+      }
+    });
   };
 
   const getCurrentPosition = () => {
@@ -118,9 +113,13 @@ const PostWriteSearchLocation = ({ setForm }) => {
 
   useEffect(() => {
     map && map.relayout();
+    map &&
+      map.setCenter(
+        new kakao.maps.LatLng(mapCenterPosition.lat, mapCenterPosition.lng)
+      );
+
     // modal과 같이 display의 값이 바뀌는 곳에서는  map.relayout() 가 필요
   }, [isModalOpen, map]);
-
   return (
     <>
       <Style.PostWriteTitle>
@@ -152,7 +151,7 @@ const PostWriteSearchLocation = ({ setForm }) => {
             height: '640px',
             borderRadius: '0px 0px 10px 10px',
           }}
-          level={5} // 지도의 확대 레벨
+          level={3} // 지도의 확대 레벨
           onCreate={setMap} //map 객체를 받아옴
           onClick={(_t, mouseEvent) => {
             // 맵을 클릭시에 실행되는 eventHandler
@@ -173,6 +172,7 @@ const PostWriteSearchLocation = ({ setForm }) => {
                 clickable={true}
                 onClick={locationSubmit}
               />
+              {console.log(markerInformation)}
               <CustomOverlayMap
                 position={{
                   lat: markerInformation.lat,

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
@@ -9,6 +9,10 @@ import PropTypes from 'prop-types';
 const PostWriteSearchLocation = ({ setForm }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [map, setMap] = useState(); //map 객체
+  const [mapCenterPosition, setMapCenterPosition] = useState({
+    lat: 37.5666805,
+    lng: 126.9784147,
+  });
 
   const [searchMarkerInformation, setSearchMarkerInformation] = useState(); // marker 클릭시 보여주는 정보객체
   const [searchResult, setSearchResult] = useState([]);
@@ -62,7 +66,6 @@ const PostWriteSearchLocation = ({ setForm }) => {
     map && map.relayout();
     // modal과 같이 display의 값이 바뀌는 곳에서는  map.relayout() 가 필요
   }, [isModalOpen, map]);
-
   return (
     <>
       <Style.PostWriteTitle>
@@ -84,11 +87,8 @@ const PostWriteSearchLocation = ({ setForm }) => {
         closeClick={toggleModal}
       >
         <Map
-          center={{
-            // 지도의 중심좌표
-            lat: 37.5666805,
-            lng: 126.9784147,
-          }}
+          center={mapCenterPosition}
+          isPanto={true}
           style={{
             // 지도의 크기
             width: '100%',
@@ -98,6 +98,7 @@ const PostWriteSearchLocation = ({ setForm }) => {
           level={8} // 지도의 확대 레벨
           onCreate={setMap} //map 객체를 받아옴
           onClick={(_t, mouseEvent) => {
+            console.log(mouseEvent);
             setClickMarkerInformation({
               lat: mouseEvent.latLng.getLat(),
               lng: mouseEvent.latLng.getLng(),
@@ -116,9 +117,7 @@ const PostWriteSearchLocation = ({ setForm }) => {
               onClick={LocationSubmit}
             >
               <Style.SearchMarker>
-                <Style.AdressName>
-                  지번: {clickMarkerInformation.address?.address_name}
-                </Style.AdressName>
+                <div>지번: {clickMarkerInformation.address?.address_name}</div>
               </Style.SearchMarker>
             </MapMarker>
           )}
@@ -127,8 +126,11 @@ const PostWriteSearchLocation = ({ setForm }) => {
             <MapMarker
               key={`marker-${data.place_name}-${data.y},${data.x}`}
               position={{ lat: data.y, lng: data.x }}
-              onMouseOver={() => setSearchMarkerInformation(data)}
-              clickable={true}
+              onMouseOver={() => {
+                setMapCenterPosition({ lat: data.y, lng: data.x });
+                setSearchMarkerInformation(data);
+              }}
+              clickable={true} //설정없으면 클릭 이벤트가 마커가아닌 지도로 인식함
               onClick={LocationSubmit}
             >
               {searchMarkerInformation &&
@@ -155,7 +157,10 @@ const PostWriteSearchLocation = ({ setForm }) => {
             {searchResult.map((data, index) => (
               <Style.SearchItem
                 key={data.id}
-                onMouseOver={() => setSearchMarkerInformation(data)}
+                onMouseOver={() => {
+                  setMapCenterPosition({ lat: data.y, lng: data.x });
+                  setSearchMarkerInformation(data);
+                }}
                 onClick={LocationSubmit}
               >
                 <Style.PlaceName>

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 
 const PostWriteSearchLocation = ({ setForm }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [locationInputValue, setLocationInputValue] = useState('');
 
   const [map, setMap] = useState(); //map 객체
   const [mapCenterPosition, setMapCenterPosition] = useState({
@@ -33,18 +34,40 @@ const PostWriteSearchLocation = ({ setForm }) => {
 
   const { kakao } = window;
   const geocoder = new kakao.maps.services.Geocoder();
+  const GetCurrentPosition = () => {
+    //현재 위치를 가져옴
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        console.log(position);
+        geocoder.coord2Address(
+          position.coords.longitude,
+          position.coords.latitude,
+          (adresses) => {
+            setLocationInputValue(adresses[0].address.address_name);
+          }
+        );
+      },
+      (error) => {
+        console.log(error);
+      },
+      {
+        enableHighAccuracy: false,
+      }
+    );
+  };
 
   const LocationSubmit = () => {
     // parent의 form state를 받아와 결과값을 추가
-    console.log('클릭이당');
+    setLocationInputValue(markerInformation.addressName);
+    setIsModalOpen(false);
   };
 
   const coord2AdressCallback = (adresses, status) => {
     if (status === 'OK') {
       setMarkerInformation((pre) => ({
         ...pre,
-        road_address: adresses[0].road_address?.address_name,
-        address: adresses[0].address.address_name,
+        roadAddressName: adresses[0].road_address?.address_name,
+        addressName: adresses[0].address.address_name,
       }));
       setIsCustomMarker(true);
     }
@@ -94,7 +117,7 @@ const PostWriteSearchLocation = ({ setForm }) => {
     <>
       <Style.PostWriteTitle>
         위치
-        <Style.FindLocationLayout>
+        <Style.FindLocationLayout onClick={GetCurrentPosition}>
           <LocationIcon />
           <Style.FindLocationMessage>현재 위치 찾기</Style.FindLocationMessage>
         </Style.FindLocationLayout>
@@ -104,6 +127,8 @@ const PostWriteSearchLocation = ({ setForm }) => {
         type="text"
         placeholder="주소를 입력하세요"
         onClick={toggleModal}
+        value={locationInputValue}
+        readOnly
       />
       <PostWriteModal
         title="위치 찾기"
@@ -140,7 +165,9 @@ const PostWriteSearchLocation = ({ setForm }) => {
               onClick={LocationSubmit}
             >
               <Style.SearchMarker>
-                <Style.PlaceName>{markerInformation?.address}</Style.PlaceName>
+                <Style.PlaceName>
+                  {markerInformation?.addressName}
+                </Style.PlaceName>
               </Style.SearchMarker>
             </MapMarker>
           )}

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
@@ -4,13 +4,32 @@ import { ReactComponent as SearchIcon } from 'assets/svg/search.svg';
 import * as Style from 'pages/PostWrite/units/PostWriteSearchLocation.styles';
 import { Map, MapMarker } from 'react-kakao-maps-sdk';
 import PostWriteModal from './PostWriteModal';
+import PropTypes from 'prop-types';
 
-const PostWriteSearchLocation = () => {
+const PostWriteSearchLocation = ({ setForm }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [map, setMap] = useState();
-  const [info, setInfo] = useState();
+  const [map, setMap] = useState(); //map 객체
+
+  const [searchMarkerInformation, setSearchMarkerInformation] = useState(); // marker 클릭시 보여주는 정보객체
   const [searchResult, setSearchResult] = useState([]);
   const [searchContent, setSearchContent] = useState('');
+
+  const [clickMarkerInformation, setClickMarkerInformation] = useState(); //마우스로 지도를 클릭했을때 마커의 정보
+  const { kakao } = window;
+  const geocoder = new kakao.maps.services.Geocoder();
+
+  const LocationSubmit = () => {
+    // parent의 form state를 받아와 결과값을 추가
+    console.log('클릭이당');
+  };
+
+  const latitudeLongitudeToAdress = (adresses) => {
+    setClickMarkerInformation((pre) => ({
+      ...pre,
+      road_address: adresses[0].road_address,
+      address: adresses[0].address,
+    }));
+  };
 
   const toggleModal = () => {
     setIsModalOpen((pre) => !pre);
@@ -22,7 +41,6 @@ const PostWriteSearchLocation = () => {
 
   const SearchMap = (event) => {
     event.preventDefault();
-    const { kakao } = window;
     const ps = new kakao.maps.services.Places();
 
     ps.keywordSearch(searchContent, (data, status) => {
@@ -31,11 +49,9 @@ const PostWriteSearchLocation = () => {
         // LatLngBounds 객체에 좌표를 추가합니다
         const bounds = new kakao.maps.LatLngBounds();
         setSearchResult(data);
-        // let markers = [];
         for (var i = 0; i < data.length; i++) {
           bounds.extend(new kakao.maps.LatLng(data[i].y, data[i].x));
         }
-
         // 검색된 장소 위치를 기준으로 지도 범위를 재설정합니다
         map.setBounds(bounds);
       }
@@ -44,6 +60,7 @@ const PostWriteSearchLocation = () => {
 
   useEffect(() => {
     map && map.relayout();
+    // modal과 같이 display의 값이 바뀌는 곳에서는  map.relayout() 가 필요
   }, [isModalOpen, map]);
 
   return (
@@ -76,24 +93,54 @@ const PostWriteSearchLocation = () => {
             // 지도의 크기
             width: '100%',
             height: '640px',
+            borderRadius: '0px 0px 10px 10px',
           }}
           level={8} // 지도의 확대 레벨
           onCreate={setMap} //map 객체를 받아옴
+          onClick={(_t, mouseEvent) => {
+            setClickMarkerInformation({
+              lat: mouseEvent.latLng.getLat(),
+              lng: mouseEvent.latLng.getLng(),
+            });
+            geocoder.coord2Address(
+              mouseEvent.latLng.getLng(),
+              mouseEvent.latLng.getLat(),
+              latitudeLongitudeToAdress
+            );
+          }}
         >
+          {clickMarkerInformation && (
+            <MapMarker
+              position={clickMarkerInformation}
+              clickable={true}
+              onClick={LocationSubmit}
+            >
+              <Style.SearchMarker>
+                <Style.AdressName>
+                  지번: {clickMarkerInformation.address?.address_name}
+                </Style.AdressName>
+              </Style.SearchMarker>
+            </MapMarker>
+          )}
+
           {searchResult.map((data) => (
             <MapMarker
               key={`marker-${data.place_name}-${data.y},${data.x}`}
               position={{ lat: data.y, lng: data.x }}
-              onMouseOver={() => setInfo(data)}
+              onMouseOver={() => setSearchMarkerInformation(data)}
+              clickable={true}
+              onClick={LocationSubmit}
             >
-              {info && info.id === data.id && (
-                <Style.SearchMarker>
-                  <Style.PlaceName>{data.place_name}</Style.PlaceName>
-                </Style.SearchMarker>
-              )}
+              {searchMarkerInformation &&
+                searchMarkerInformation.id === data.id && (
+                  <Style.SearchMarker>
+                    <Style.PlaceName>{data.place_name}</Style.PlaceName>
+                  </Style.SearchMarker>
+                )}
             </MapMarker>
           ))}
         </Map>
+
         <Style.SearchInformationSideBar>
           <Style.SearchForm onSubmit={SearchMap}>
             <Style.SearchInput
@@ -103,9 +150,14 @@ const PostWriteSearchLocation = () => {
               iconClick={SearchMap}
             />
           </Style.SearchForm>
+
           <Style.SearchResult>
             {searchResult.map((data, index) => (
-              <Style.SearchItem key={data.id} onMouseOver={() => setInfo(data)}>
+              <Style.SearchItem
+                key={data.id}
+                onMouseOver={() => setSearchMarkerInformation(data)}
+                onClick={LocationSubmit}
+              >
                 <Style.PlaceName>
                   {index + 1 + '. ' + data.place_name}
                 </Style.PlaceName>
@@ -120,6 +172,10 @@ const PostWriteSearchLocation = () => {
       </PostWriteModal>
     </>
   );
+};
+
+PostWriteSearchLocation.propTypes = {
+  setForm: PropTypes.object,
 };
 
 export default PostWriteSearchLocation;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
@@ -104,7 +104,7 @@ const PostWriteSearchLocation = ({ setForm }) => {
     });
   };
 
-  const LocationSubmit = () => {
+  const locationSubmit = () => {
     // parent의 form state를 받아와 결과값을 추가
     setLocationInputValue(markerInformation.addressName);
     setIsModalOpen(false);
@@ -171,8 +171,8 @@ const PostWriteSearchLocation = ({ setForm }) => {
                   lng: markerInformation.lng,
                 }}
                 clickable={true}
-                onClick={LocationSubmit}
-              ></MapMarker>
+                onClick={locationSubmit}
+              />
               <CustomOverlayMap
                 position={{
                   lat: markerInformation.lat,
@@ -205,8 +205,8 @@ const PostWriteSearchLocation = ({ setForm }) => {
                   });
                 }}
                 clickable={true}
-                onClick={LocationSubmit}
-              ></MapMarker>
+                onClick={locationSubmit}
+              />
               {!isCustomMarker && (
                 <CustomOverlayMap
                   position={{
@@ -250,7 +250,7 @@ const PostWriteSearchLocation = ({ setForm }) => {
                     roadAddressName: data.road_address_name,
                   });
                 }}
-                onClick={LocationSubmit}
+                onClick={locationSubmit}
               >
                 <Style.PlaceName>
                   {index + 1 + '. ' + data.place_name}

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+
+export const PostWriteTitle = styled.h3`
+  font-size: 18px;
+`;
+
+export const FindLocationLayout = styled.div`
+  display: inline-block;
+  margin-left: 10px;
+  cursor: pointer;
+  > svg {
+    width: 15px;
+    height: 15px;
+    vertical-align: middle;
+    > path {
+      stroke: ${({ theme }) => theme.blue[900]};
+    }
+  }
+`;
+
+export const FindLocationMessage = styled.span`
+  font-size: 14px;
+  color: ${({ theme }) => theme.blue[900]};
+  vertical-align: middle;
+`;
+
+export const LocationInput = styled.input`
+  width: 410px;
+  padding: 10px;
+  margin-top: 20px;
+  border: solid 1px ${({ theme }) => theme.gray[500]};
+  border-radius: 10px;
+`;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
@@ -53,6 +53,9 @@ export const SearchForm = styled.form`
 
 export const SearchMarker = styled.div`
   padding: 5px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
 `;
 
 export const SearchInput = styled(Input)`
@@ -78,7 +81,7 @@ export const RoadAdressName = styled.p`
   font-size: 10px;
 `;
 
-export const AdressName = styled.p`
+export const AdressName = styled.span`
   font-size: 8px;
   color: ${({ theme }) => theme.gray[600]};
 `;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
@@ -35,13 +35,13 @@ export const LocationInput = styled.input`
 `;
 
 export const SearchInformationSideBar = styled.div`
-  padding: 5px;
   position: absolute;
   top: 80px;
   left: 20px;
   z-index: 10;
   height: 600px;
   width: 185px;
+  padding: 5px;
   border-radius: 10px;
   background-color: ${({ theme }) => theme.opacityWhite};
 `;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
@@ -53,9 +53,10 @@ export const SearchForm = styled.form`
 
 export const SearchMarker = styled.div`
   padding: 5px;
-  text-overflow: ellipsis;
-  overflow: hidden;
-  white-space: nowrap;
+  border: solid 2px ${({ theme }) => theme.gray[500]};
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.white};
+  font-size: 12px;
 `;
 
 export const SearchInput = styled(Input)`
@@ -76,12 +77,12 @@ export const PlaceName = styled.p`
   font-size: 12px;
 `;
 
-export const RoadAdressName = styled.p`
+export const RoadAddressName = styled.p`
   margin-top: 5px;
   font-size: 10px;
 `;
 
-export const AdressName = styled.span`
+export const AddressName = styled.p`
   font-size: 8px;
   color: ${({ theme }) => theme.gray[600]};
 `;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
@@ -1,3 +1,5 @@
+import Input from 'components/Input/Input';
+import { ScrollBarY } from 'components/ScrollBar/ScrollBar';
 import styled from 'styled-components';
 
 export const PostWriteTitle = styled.h3`
@@ -30,4 +32,53 @@ export const LocationInput = styled.input`
   margin-top: 20px;
   border: solid 1px ${({ theme }) => theme.gray[500]};
   border-radius: 10px;
+`;
+
+export const SearchInformationSideBar = styled.div`
+  padding: 5px;
+  position: absolute;
+  top: 80px;
+  left: 20px;
+  z-index: 10;
+  height: 600px;
+  width: 185px;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.opacityWhite};
+`;
+
+export const SearchForm = styled.form`
+  display: flex;
+  padding: 10px;
+`;
+
+export const SearchMarker = styled.div`
+  padding: 5px;
+`;
+
+export const SearchInput = styled(Input)`
+  position: sticky;
+  background-color: ${({ theme }) => theme.gray[300]};
+`;
+
+export const SearchResult = styled(ScrollBarY)`
+  height: 520px;
+  overflow-y: scroll;
+`;
+
+export const SearchItem = styled.div`
+  padding: 10px;
+`;
+
+export const PlaceName = styled.p`
+  font-size: 12px;
+`;
+
+export const RoadAdressName = styled.p`
+  margin-top: 5px;
+  font-size: 10px;
+`;
+
+export const AdressName = styled.p`
+  font-size: 8px;
+  color: ${({ theme }) => theme.gray[600]};
 `;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadForm.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadForm.styles.js
@@ -49,15 +49,15 @@ export const UploadCount = styled.p`
 
 export const UploadPreviewLayout = styled.div`
   display: flex;
-  align-items: center;
   margin-left: 20px;
+  align-items: center;
 `;
 
 export const Carousel = styled(ScrollBarX)`
   width: 520px;
   height: 180px;
-  overflow-x: scroll;
   white-space: nowrap;
+  overflow-x: scroll;
   > * {
     margin-right: 10px;
     margin-left: 10px;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
@@ -1,10 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 import * as Style from 'pages/PostWrite/units/PostWriteUploadMediaForm.styles';
 import { ReactComponent as PlusIcon } from 'assets/svg/Plus.svg';
 import { ReactComponent as LeftArrowIcon } from 'assets/svg/left_arrow_line.svg';
 import { ReactComponent as RightArrowIcon } from 'assets/svg/right_arrow_line.svg';
 import { ReactComponent as XMarkIcon } from 'assets/svg/x_mark.svg';
-import { useRef } from 'react';
 
 const PostUploadMediaForm = () => {
   const caruselRef = useRef();
@@ -17,26 +16,29 @@ const PostUploadMediaForm = () => {
   };
 
   const deleteFile = (target) => {
+    window.URL.revokeObjectURL(filesThumbnail[target]);
     setFilesThumbnail((pre) => pre.filter((item, index) => index !== target));
   };
 
   const handleAddFiles = (event) => {
     const fileLists = event.target.files;
-    let fileList = [...filesThumbnail];
 
-    for (let i = 0; i < fileLists.length; i++) {
-      const currentFileUrl = URL.createObjectURL(fileLists[i]);
-      if (fileLists[i].type.match(/image\//g)) {
-        fileList.push({ url: currentFileUrl, type: 'image' });
-      } else if (fileLists[i].type.match(/video\//g)) {
-        fileList.push({ url: currentFileUrl, type: 'video' });
-      } else {
-        console.log('타입오류');
+    if (filesThumbnail.length + fileLists.length > 20) {
+      alert('업로드 개수를 초과하였습니다');
+    } else {
+      let fileList = [...filesThumbnail];
+      for (let i = 0; i < fileLists.length; i++) {
+        const currentFileUrl = URL.createObjectURL(fileLists[i]);
+        if (fileLists[i].type.match(/image\//g)) {
+          fileList.push({ url: currentFileUrl, type: 'image' });
+        } else if (fileLists[i].type.match(/video\//g)) {
+          fileList.push({ url: currentFileUrl, type: 'video' });
+        } else {
+          alert('이미지, 동영상 파일을 업로드해 주세요');
+        }
       }
+      setFilesThumbnail(fileList);
     }
-
-    fileList.length > 20 && (fileList = fileList.slice(0, 20));
-    setFilesThumbnail(fileList);
   };
 
   return (
@@ -47,14 +49,14 @@ const PostUploadMediaForm = () => {
           <Style.PlusIconContainer>
             <PlusIcon />
           </Style.PlusIconContainer>
-          <Style.UploadCount>0</Style.UploadCount>
+          <Style.UploadCount>{filesThumbnail.length}</Style.UploadCount>
         </Style.UploadFileBox>
         <Style.FileUploadInput
           id="multiple-file"
           type="file"
           onChange={handleAddFiles}
           multiple
-        ></Style.FileUploadInput>
+        />
 
         <Style.UploadPreviewLayout>
           <Style.ArrowIconContainer>
@@ -66,7 +68,7 @@ const PostUploadMediaForm = () => {
                 if (file.type === 'image') {
                   return (
                     <Style.PreviewImageContainer key={index}>
-                      <Style.PreviewImage src={file.url}></Style.PreviewImage>
+                      <Style.PreviewImage src={file.url} />
                       <Style.XMarkIconContainer
                         onClick={() => deleteFile(index)}
                       >
@@ -77,7 +79,7 @@ const PostUploadMediaForm = () => {
                 } else if (file.type === 'video') {
                   return (
                     <Style.PreviewImageContainer key={index}>
-                      <Style.PreviewVedio src={file.url}></Style.PreviewVedio>
+                      <Style.PreviewVedio src={file.url} />
                       <Style.XMarkIconContainer
                         onClick={() => deleteFile(index)}
                       >
@@ -85,6 +87,8 @@ const PostUploadMediaForm = () => {
                       </Style.XMarkIconContainer>
                     </Style.PreviewImageContainer>
                   );
+                } else {
+                  return <></>;
                 }
               })}
           </Style.Carousel>

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
@@ -73,33 +73,18 @@ const PostUploadMediaForm = () => {
           </Style.ArrowIconContainer>
           <Style.Carousel ref={caruselRef}>
             {filesThumbnail &&
-              filesThumbnail.map((file, index) => {
-                if (file.type === 'image') {
-                  return (
-                    <Style.PreviewImageContainer key={index}>
-                      <Style.PreviewImage src={file.url} />
-                      <Style.XMarkIconContainer
-                        onClick={() => deleteFile(index)}
-                      >
-                        <XMarkIcon />
-                      </Style.XMarkIconContainer>
-                    </Style.PreviewImageContainer>
-                  );
-                } else if (file.type === 'video') {
-                  return (
-                    <Style.PreviewImageContainer key={index}>
-                      <Style.PreviewVedio src={file.url} />
-                      <Style.XMarkIconContainer
-                        onClick={() => deleteFile(index)}
-                      >
-                        <XMarkIcon />
-                      </Style.XMarkIconContainer>
-                    </Style.PreviewImageContainer>
-                  );
-                } else {
-                  return <></>;
-                }
-              })}
+              filesThumbnail.map((file, index) => (
+                <Style.PreviewImageContainer key={index}>
+                  {file.type === 'image' ? (
+                    <Style.PreviewImage src={file.url} />
+                  ) : (
+                    <Style.PreviewVideo src={file.url} />
+                  )}
+                  <Style.XMarkIconContainer onClick={() => deleteFile(index)}>
+                    <XMarkIcon />
+                  </Style.XMarkIconContainer>
+                </Style.PreviewImageContainer>
+              ))}
           </Style.Carousel>
           <Style.ArrowIconContainer>
             <RightArrowIcon onClick={RightCaruselClick} />

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
@@ -74,7 +74,7 @@ const PostUploadMediaForm = () => {
           <Style.Carousel ref={caruselRef}>
             {filesThumbnail &&
               filesThumbnail.map((file, index) => (
-                <Style.PreviewImageContainer key={index}>
+                <Style.PreviewImageContainer key={`file-${index}`}>
                   {file.type === 'image' ? (
                     <Style.PreviewImage src={file.url} />
                   ) : (

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
@@ -1,5 +1,5 @@
-import React from 'react';
-import * as Style from 'pages/PostWrite/units/PostWriteUploadForm.styles';
+import React, { useState } from 'react';
+import * as Style from 'pages/PostWrite/units/PostWriteUploadMediaForm.styles';
 import { ReactComponent as PlusIcon } from 'assets/svg/Plus.svg';
 import { ReactComponent as LeftArrowIcon } from 'assets/svg/left_arrow_line.svg';
 import { ReactComponent as RightArrowIcon } from 'assets/svg/right_arrow_line.svg';
@@ -8,76 +8,85 @@ import { useRef } from 'react';
 
 const PostUploadMediaForm = () => {
   const caruselRef = useRef();
+  const [filesThumbnail, setFilesThumbnail] = useState([]);
   const LeftCaruselClick = () => {
     caruselRef.current.scrollLeft -= 500;
   };
   const RightCaruselClick = () => {
     caruselRef.current.scrollLeft += 500;
   };
+
+  const deleteFile = (target) => {
+    setFilesThumbnail((pre) => pre.filter((item, index) => index !== target));
+  };
+
+  const handleAddFiles = (event) => {
+    const fileLists = event.target.files;
+    let fileList = [...filesThumbnail];
+
+    for (let i = 0; i < fileLists.length; i++) {
+      const currentFileUrl = URL.createObjectURL(fileLists[i]);
+      if (fileLists[i].type.match(/image\//g)) {
+        fileList.push({ url: currentFileUrl, type: 'image' });
+      } else if (fileLists[i].type.match(/video\//g)) {
+        fileList.push({ url: currentFileUrl, type: 'video' });
+      } else {
+        console.log('타입오류');
+      }
+    }
+
+    fileList.length > 20 && (fileList = fileList.slice(0, 20));
+    setFilesThumbnail(fileList);
+  };
+
   return (
     <Style.UploadLayout>
       <Style.UploadTitle>사진/동영상 업로드</Style.UploadTitle>
       <Style.UploadForm>
-        <Style.UploadFileBox>
+        <Style.UploadFileBox htmlFor="multiple-file">
           <Style.PlusIconContainer>
             <PlusIcon />
           </Style.PlusIconContainer>
           <Style.UploadCount>0</Style.UploadCount>
         </Style.UploadFileBox>
+        <Style.FileUploadInput
+          id="multiple-file"
+          type="file"
+          onChange={handleAddFiles}
+          multiple
+        ></Style.FileUploadInput>
 
         <Style.UploadPreviewLayout>
           <Style.ArrowIconContainer>
             <LeftArrowIcon onClick={LeftCaruselClick} />
           </Style.ArrowIconContainer>
           <Style.Carousel ref={caruselRef}>
-            <Style.UploadPreviewImage>
-              <Style.UploadBox></Style.UploadBox>
-              <Style.XMarkIconContainer>
-                <XMarkIcon />
-              </Style.XMarkIconContainer>
-            </Style.UploadPreviewImage>
-
-            <Style.UploadPreviewImage>
-              <Style.UploadBox></Style.UploadBox>
-              <Style.XMarkIconContainer>
-                <XMarkIcon />
-              </Style.XMarkIconContainer>
-            </Style.UploadPreviewImage>
-
-            <Style.UploadPreviewImage>
-              <Style.UploadBox></Style.UploadBox>
-              <Style.XMarkIconContainer>
-                <XMarkIcon />
-              </Style.XMarkIconContainer>
-            </Style.UploadPreviewImage>
-
-            <Style.UploadPreviewImage>
-              <Style.UploadBox></Style.UploadBox>
-              <Style.XMarkIconContainer>
-                <XMarkIcon />
-              </Style.XMarkIconContainer>
-            </Style.UploadPreviewImage>
-
-            <Style.UploadPreviewImage>
-              <Style.UploadBox></Style.UploadBox>
-              <Style.XMarkIconContainer>
-                <XMarkIcon />
-              </Style.XMarkIconContainer>
-            </Style.UploadPreviewImage>
-
-            <Style.UploadPreviewImage>
-              <Style.UploadBox></Style.UploadBox>
-              <Style.XMarkIconContainer>
-                <XMarkIcon />
-              </Style.XMarkIconContainer>
-            </Style.UploadPreviewImage>
-
-            <Style.UploadPreviewImage>
-              <Style.UploadBox></Style.UploadBox>
-              <Style.XMarkIconContainer>
-                <XMarkIcon />
-              </Style.XMarkIconContainer>
-            </Style.UploadPreviewImage>
+            {filesThumbnail &&
+              filesThumbnail.map((file, index) => {
+                if (file.type === 'image') {
+                  return (
+                    <Style.PreviewImageContainer key={index}>
+                      <Style.PreviewImage src={file.url}></Style.PreviewImage>
+                      <Style.XMarkIconContainer
+                        onClick={() => deleteFile(index)}
+                      >
+                        <XMarkIcon />
+                      </Style.XMarkIconContainer>
+                    </Style.PreviewImageContainer>
+                  );
+                } else if (file.type === 'video') {
+                  return (
+                    <Style.PreviewImageContainer key={index}>
+                      <Style.PreviewVedio src={file.url}></Style.PreviewVedio>
+                      <Style.XMarkIconContainer
+                        onClick={() => deleteFile(index)}
+                      >
+                        <XMarkIcon />
+                      </Style.XMarkIconContainer>
+                    </Style.PreviewImageContainer>
+                  );
+                }
+              })}
           </Style.Carousel>
           <Style.ArrowIconContainer>
             <RightArrowIcon onClick={RightCaruselClick} />

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
@@ -20,9 +20,7 @@ const PostUploadMediaForm = () => {
     setFilesThumbnail((pre) => pre.filter((item, index) => index !== target));
   };
 
-  const handleAddFiles = (event) => {
-    const fileLists = event.target.files;
-
+  const handleAddFiles = (fileLists) => {
     if (filesThumbnail.length + fileLists.length > 20) {
       alert('업로드 개수를 초과하였습니다');
     } else {
@@ -41,10 +39,21 @@ const PostUploadMediaForm = () => {
     }
   };
 
+  const dragDropUpload = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    handleAddFiles(event.dataTransfer.files);
+  };
+
+  const dragOverHandler = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
   return (
     <Style.UploadLayout>
       <Style.UploadTitle>사진/동영상 업로드</Style.UploadTitle>
-      <Style.UploadForm>
+      <Style.UploadForm onDrop={dragDropUpload} onDragOver={dragOverHandler}>
         <Style.UploadFileBox htmlFor="multiple-file">
           <Style.PlusIconContainer>
             <PlusIcon />
@@ -54,7 +63,7 @@ const PostUploadMediaForm = () => {
         <Style.FileUploadInput
           id="multiple-file"
           type="file"
-          onChange={handleAddFiles}
+          onChange={(event) => handleAddFiles(event.target.files)}
           multiple
         />
 

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
@@ -9,10 +9,16 @@ const PostUploadMediaForm = () => {
   const caruselRef = useRef();
   const [filesThumbnail, setFilesThumbnail] = useState([]);
   const LeftCaruselClick = () => {
-    caruselRef.current.scrollLeft -= 500;
+    caruselRef.current.scrollTo({
+      left: caruselRef.current.scrollLeft - 500,
+      behavior: 'smooth',
+    });
   };
   const RightCaruselClick = () => {
-    caruselRef.current.scrollLeft += 500;
+    caruselRef.current.scrollTo({
+      left: caruselRef.current.scrollLeft + 500,
+      behavior: 'smooth',
+    });
   };
 
   const deleteFile = (target) => {

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.styles.js
@@ -61,7 +61,7 @@ export const Carousel = styled(ScrollBarX)`
   width: 520px;
   height: 180px;
   white-space: nowrap;
-  overflow-x: scroll;
+  overflow-x: auto;
   > * {
     margin-right: 10px;
     margin-left: 10px;
@@ -82,7 +82,7 @@ export const PreviewImage = styled.img`
   object-fit: cover;
 `;
 
-export const PreviewVedio = styled.video`
+export const PreviewVideo = styled.video`
   width: 130px;
   height: 130px;
   border-radius: 10px;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.styles.js
@@ -19,7 +19,7 @@ export const UploadForm = styled.div`
   justify-content: center;
 `;
 
-export const UploadFileBox = styled.div`
+export const UploadFileBox = styled.label`
   display: flex;
   width: 130px;
   height: 130px;
@@ -31,6 +31,10 @@ export const UploadFileBox = styled.div`
   align-items: center;
   flex-direction: column;
   cursor: pointer;
+`;
+
+export const FileUploadInput = styled.input`
+  display: none;
 `;
 
 export const PlusIconContainer = styled.div`
@@ -64,13 +68,20 @@ export const Carousel = styled(ScrollBarX)`
   }
 `;
 
-export const UploadPreviewImage = styled.div`
+export const PreviewImageContainer = styled.div`
   display: inline-block;
   position: relative;
   padding: 10px;
 `;
 
-export const UploadBox = styled.img`
+export const PreviewImage = styled.img`
+  width: 130px;
+  height: 130px;
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.blue[300]};
+`;
+
+export const PreviewVedio = styled.video`
   width: 130px;
   height: 130px;
   border-radius: 10px;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.styles.js
@@ -47,7 +47,7 @@ export const UploadCount = styled.p`
   color: ${({ theme }) => theme.brown};
   &::after {
     color: ${({ theme }) => theme.blue[900]};
-    content: '/10';
+    content: '/20';
   }
 `;
 
@@ -79,6 +79,7 @@ export const PreviewImage = styled.img`
   height: 130px;
   border-radius: 10px;
   background-color: ${({ theme }) => theme.blue[300]};
+  object-fit: cover;
 `;
 
 export const PreviewVedio = styled.video`
@@ -86,6 +87,7 @@ export const PreviewVedio = styled.video`
   height: 130px;
   border-radius: 10px;
   background-color: ${({ theme }) => theme.blue[300]};
+  object-fit: cover;
 `;
 
 export const XMarkIconContainer = styled.div`

--- a/breaking-front/src/styles/theme.js
+++ b/breaking-front/src/styles/theme.js
@@ -10,6 +10,7 @@ const theme = {
   black: PALETTE.BLACK,
   brown: PALETTE.BROWN,
   opacityBlack: PALETTE.OPACITY_BLACK,
+  opacityWhite: PALETTE.OPACITY_WHITE,
 };
 
 export default theme;

--- a/breaking-front/src/utils/parseAddressName.js
+++ b/breaking-front/src/utils/parseAddressName.js
@@ -1,0 +1,9 @@
+const parseAddressName = (address) => {
+  const splited = address.split(' ');
+  return {
+    region_1depth_name: splited[0],
+    region_2depth_name: splited[1],
+  };
+};
+
+export default parseAddressName;


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #143 

## 예상 리뷰 시간
20-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
카카오맵 변경사항 #148 PR이후
1. 오버레이를 커스텀 오버레이로 변환
2. 현재 위치를 바로 불러오는것이 아닌 modal을 띄워서 현재위치를 마커로 찍어줌
3. 상세주소를 시군구 까지 객체로 만들어주는 parser추가

이미지 업로드 변경사항
1. 다중 이미지 업로드 구현
2. 드래그 앤 드랍 이미지 구현
3. 이미지, 동영상 파일이 아닐시 alert 창 뜨게 사용
4. 업로드가 20개가 넘어가면 alert 처리 및 추가 불가능

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
clone후 직접 테스트 추천

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
1. 드래그 앤 드랍 이벤트시에 화면이 바뀌도록 
![image](https://user-images.githubusercontent.com/49224104/182760674-4424bc86-37e8-4ebd-b7c4-cb746bc03cf4.png)
이런 느낌으로 가는게 좋을거 같습니다 아마 프로필 이미지 업로드도 수정해야 하니 디자인을 통일하고 가는게 좋을거 같아요
2. 이미지 파일 변환 할떄 base64를 사용하셨던데 https://velog.io/@kykim/readAsDataURL-vs-createObjectURL readAsDataURL로 바꾸는거 어떨까요? 그리고 utils의 fileToBase64가 단일 파일 처리만 가능해서 사용하지 못했습니다 수정 한번 필요할것 같습니다.