### PR TITLE
feat: post write 페이지 데이터 백엔드로 넘기는 로직  추가

### DIFF
--- a/breaking-front/src/api/postWrite.js
+++ b/breaking-front/src/api/postWrite.js
@@ -5,6 +5,7 @@ export const postPostWrite = (data) => {
   return api({
     method: 'post',
     url: API_PATH.POST_WRITE,
+    'Content-Type': 'multipart/form-data',
     data: data,
   });
 };

--- a/breaking-front/src/api/postWrite.js
+++ b/breaking-front/src/api/postWrite.js
@@ -1,0 +1,10 @@
+import { API_PATH } from 'constants/path';
+import api from 'api/api';
+
+export const postPostWrite = (data) => {
+  return api({
+    method: 'post',
+    url: API_PATH.POST_WRITE,
+    data: data,
+  });
+};

--- a/breaking-front/src/constants/message.js
+++ b/breaking-front/src/constants/message.js
@@ -6,6 +6,12 @@ const MESSAGE = {
     SUBMIT_INVALID_EMAIL: '이메일을 올바르게 기입해주시기 바랍니다.',
     WRONG_ACCESS: 'SNS 로그인 후 회원가입이 가능함니다.',
   },
+
+  POST_WRITE: {
+    LOCATION_BLANK: '제보가 발생한 위치를 입력해 주시기 바랍니다.',
+    TITLE_BLANK: '제목을 입력해 주시기 바랍니다.',
+    CONTENT_BLANK: '본문을 입력해 주시기 바랍니다.',
+  },
 };
 
 export default MESSAGE;

--- a/breaking-front/src/mocks/handlers.js
+++ b/breaking-front/src/mocks/handlers.js
@@ -4,6 +4,7 @@ import { signInHandlers } from 'mocks/signInHandlers';
 import { signUpHandlers } from 'mocks/signUpHandlers';
 import { mainFeedHandlers } from 'mocks/mainFeedHandlers';
 import { postHandlers } from 'mocks/postHandlers';
+import { postWriteHandlers } from 'mocks/postWriteHandlers';
 
 export const handlers = [
   ...profileSettingHandlers,
@@ -12,4 +13,5 @@ export const handlers = [
   ...signUpHandlers,
   ...mainFeedHandlers,
   ...postHandlers,
+  ...postWriteHandlers,
 ];

--- a/breaking-front/src/mocks/postWriteHandlers.js
+++ b/breaking-front/src/mocks/postWriteHandlers.js
@@ -1,0 +1,9 @@
+import { API_PATH } from 'constants/path';
+import { rest } from 'msw';
+
+export const postWriteHandlers = [
+  rest.post(API_PATH.POST_WRITE, (req, res, ctx) => {
+    console.log(req.body);
+    return res(ctx.status(200));
+  }),
+];

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -5,38 +5,34 @@ import 'react-datepicker/dist/react-datepicker.css';
 import dayjs from 'dayjs';
 import PostWriteSearchLocation from 'pages/PostWrite/units/PostWriteSearchLocation';
 import useInputs from 'hooks/useInputs';
+import { useMutation } from 'react-query';
+import { postPostWrite } from 'api/postWrite';
 
 const PostWrite = () => {
-  const [occurDate, setOccurDate] = useState(dayjs().format('YYYY-MM-DD'));
-  const [occurTime, setOccurTime] = useState(dayjs().format('HH:mm'));
-
   const [isShowPriceInput, setIsShowPriceInput] = useState(false);
 
-  const [postData, onChangePostData, setPostData] = useInputs({
+  const [postWriteData, onChangePostWriteData, setPostWriteData] = useInputs({
+    location: undefined,
+    eventTime: dayjs().format('YYYY-MM-DDTHH:mm'),
     title: '',
     content: '',
     price: 0,
     postType: 'charged',
     isAnonymous: false,
+    thumbnailIndex: 0,
   });
 
-  console.log(postData);
+  const { mutate: PostWriteMutate } = useMutation(postPostWrite);
 
   const SetPrivate = () => {
-    setPostData((pre) => ({ ...pre, isAnonymous: true }));
+    setPostWriteData((pre) => ({ ...pre, isAnonymous: true }));
   };
   const SetPublic = () => {
-    setPostData((pre) => ({ ...pre, isAnonymous: false }));
+    setPostWriteData((pre) => ({ ...pre, isAnonymous: false }));
   };
 
-  const handleOccurDate = (event) => {
-    setOccurDate(event.target.value);
-  };
-  const handleOccurTime = (event) => {
-    setOccurTime(event.target.value);
-  };
   const handlePrice = (event) => {
-    setPostData((pre) => ({ ...pre, price: Number(event.target.value) }));
+    setPostWriteData((pre) => ({ ...pre, price: Number(event.target.value) }));
   };
 
   const toggleShowPirceInput = () => {
@@ -49,37 +45,42 @@ const PostWrite = () => {
     }
   };
 
+  const postWriteSubmit = (event) => {
+    event.preventDefault();
+    PostWriteMutate({
+      data: JSON.stringify({
+        ...postWriteData,
+        eventTime: postWriteData.eventTime.format('YYYY-MM-DD HH:ss:ss'),
+      }),
+    });
+  };
   return (
     <Style.Container>
       <PostUploadMediaForm />
       <Style.OccurTimeLayout>
         <Style.PostWriteTitle>제보 발생 시간</Style.PostWriteTitle>
         <Style.DatePicker
-          type="date"
-          value={occurDate}
-          onChange={handleOccurDate}
-        ></Style.DatePicker>
-        <Style.DatePicker
-          type="time"
-          value={occurTime}
-          onChange={handleOccurTime}
+          type="datetime-local"
+          name="eventTime"
+          value={postWriteData.eventTime}
+          onChange={onChangePostWriteData}
         ></Style.DatePicker>
       </Style.OccurTimeLayout>
 
       <Style.LocationLayout>
-        <PostWriteSearchLocation />
+        <PostWriteSearchLocation setPostWriteData={setPostWriteData} />
       </Style.LocationLayout>
 
       <Style.ContextLayout>
         <Style.ContextTitleInput
           type="text"
           placeholder="제목을 입력하세요"
-          onChange={onChangePostData}
+          onChange={onChangePostWriteData}
           name="title"
         ></Style.ContextTitleInput>
         <Style.ContextBodyTextArea
           placeholder="상황을 최대한 상세하게 기록해 주세요&#13;(상황, 시간, 사건 전개과정, 경과상태 등)&#13;&#10;최대 2000자"
-          onChange={onChangePostData}
+          onChange={onChangePostWriteData}
           name="content"
         ></Style.ContextBodyTextArea>
       </Style.ContextLayout>
@@ -87,26 +88,26 @@ const PostWrite = () => {
       <Style.PostTypeLayout>
         <Style.PostWriteTitle>제보 방식</Style.PostWriteTitle>
         <Style.PostRadioButton
-          onClick={onChangePostData}
+          onClick={onChangePostWriteData}
           value="charged"
           name="postType"
-          radioControl={postData.postType}
+          radioControl={postWriteData.postType}
         >
           유료제보
         </Style.PostRadioButton>
         <Style.PostRadioButton
-          onClick={onChangePostData}
+          onClick={onChangePostWriteData}
           value="free"
           name="postType"
-          radioControl={postData.postType}
+          radioControl={postWriteData.postType}
         >
           무료제보
         </Style.PostRadioButton>
         <Style.PostRadioButton
-          onClick={onChangePostData}
+          onClick={onChangePostWriteData}
           value="exclusive"
           name="postType"
-          radioControl={postData.postType}
+          radioControl={postWriteData.postType}
         >
           단독제보
         </Style.PostRadioButton>
@@ -120,8 +121,8 @@ const PostWrite = () => {
           maxLength="15"
           value={
             isShowPriceInput
-              ? postData.price
-              : postData.price.toLocaleString('ko-KR') + '원'
+              ? postWriteData.price
+              : postWriteData.price.toLocaleString('ko-KR') + '원'
           }
           onChange={handlePrice}
           onBlur={toggleShowPirceInput}
@@ -134,14 +135,14 @@ const PostWrite = () => {
         <Style.PostRadioButton
           onClick={SetPrivate}
           value={true}
-          radioControl={postData.isAnonymous}
+          radioControl={postWriteData.isAnonymous}
         >
           비공개
         </Style.PostRadioButton>
         <Style.PostRadioButton
           onClick={SetPublic}
           value={false}
-          radioControl={postData.isAnonymous}
+          radioControl={postWriteData.isAnonymous}
         >
           공개
         </Style.PostRadioButton>

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -4,20 +4,29 @@ import PostUploadMediaForm from 'pages/PostWrite/units/PostWriteUploadMediaForm'
 import 'react-datepicker/dist/react-datepicker.css';
 import dayjs from 'dayjs';
 import PostWriteSearchLocation from 'pages/PostWrite/units/PostWriteSearchLocation';
+import useInputs from 'hooks/useInputs';
 
 const PostWrite = () => {
   const [occurDate, setOccurDate] = useState(dayjs().format('YYYY-MM-DD'));
   const [occurTime, setOccurTime] = useState(dayjs().format('HH:mm'));
-  const [selectedPostType, setSelectedPostType] = useState('charged');
-  const [selectedAnonymous, setSelectedAnonymous] = useState('public');
-  const [price, setPrice] = useState(0);
+
   const [isShowPriceInput, setIsShowPriceInput] = useState(false);
 
-  const handlePostType = (event) => {
-    setSelectedPostType(event.target.id);
+  const [postData, onChangePostData, setPostData] = useInputs({
+    title: '',
+    content: '',
+    price: 0,
+    postType: 'charged',
+    isAnonymous: false,
+  });
+
+  console.log(postData);
+
+  const SetPrivate = () => {
+    setPostData((pre) => ({ ...pre, isAnonymous: true }));
   };
-  const handleAnonymous = (event) => {
-    setSelectedAnonymous(event.target.id);
+  const SetPublic = () => {
+    setPostData((pre) => ({ ...pre, isAnonymous: false }));
   };
 
   const handleOccurDate = (event) => {
@@ -27,7 +36,7 @@ const PostWrite = () => {
     setOccurTime(event.target.value);
   };
   const handlePrice = (event) => {
-    setPrice(Number(event.target.value));
+    setPostData((pre) => ({ ...pre, price: Number(event.target.value) }));
   };
 
   const toggleShowPirceInput = () => {
@@ -65,9 +74,13 @@ const PostWrite = () => {
         <Style.ContextTitleInput
           type="text"
           placeholder="제목을 입력하세요"
+          onChange={onChangePostData}
+          name="title"
         ></Style.ContextTitleInput>
         <Style.ContextBodyTextArea
           placeholder="상황을 최대한 상세하게 기록해 주세요&#13;(상황, 시간, 사건 전개과정, 경과상태 등)&#13;&#10;최대 2000자"
+          onChange={onChangePostData}
+          name="content"
         ></Style.ContextBodyTextArea>
         <Style.ContextHashTagInput placeholder="#해시태그를 입력하세요. (최대 8개)"></Style.ContextHashTagInput>
       </Style.ContextLayout>
@@ -75,23 +88,26 @@ const PostWrite = () => {
       <Style.PostTypeLayout>
         <Style.PostWriteTitle>제보 방식</Style.PostWriteTitle>
         <Style.PostRadioButton
-          onClick={handlePostType}
-          id="charged"
-          radioControl={selectedPostType}
+          onClick={onChangePostData}
+          value="charged"
+          name="postType"
+          radioControl={postData.postType}
         >
           유료제보
         </Style.PostRadioButton>
         <Style.PostRadioButton
-          onClick={handlePostType}
-          id="free"
-          radioControl={selectedPostType}
+          onClick={onChangePostData}
+          value="free"
+          name="postType"
+          radioControl={postData.postType}
         >
           무료제보
         </Style.PostRadioButton>
         <Style.PostRadioButton
-          onClick={handlePostType}
-          id="exclusive"
-          radioControl={selectedPostType}
+          onClick={onChangePostData}
+          value="exclusive"
+          name="postType"
+          radioControl={postData.postType}
         >
           단독제보
         </Style.PostRadioButton>
@@ -104,7 +120,9 @@ const PostWrite = () => {
           onInput={maxLengthCheck}
           maxLength="15"
           value={
-            isShowPriceInput ? price : price.toLocaleString('ko-KR') + '원'
+            isShowPriceInput
+              ? postData.price
+              : postData.price.toLocaleString('ko-KR') + '원'
           }
           onChange={handlePrice}
           onBlur={toggleShowPirceInput}
@@ -115,16 +133,16 @@ const PostWrite = () => {
       <Style.AnonymousLayout>
         <Style.PostWriteTitle>프로필을 공개하시겠습니까?</Style.PostWriteTitle>
         <Style.PostRadioButton
-          onClick={handleAnonymous}
-          id="private"
-          radioControl={selectedAnonymous}
+          onClick={SetPrivate}
+          value={true}
+          radioControl={postData.isAnonymous}
         >
           비공개
         </Style.PostRadioButton>
         <Style.PostRadioButton
-          onClick={handleAnonymous}
-          id="public"
-          radioControl={selectedAnonymous}
+          onClick={SetPublic}
+          value={false}
+          radioControl={postData.isAnonymous}
         >
           공개
         </Style.PostRadioButton>

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -11,6 +11,7 @@ import { postPostWrite } from 'api/postWrite';
 const PostWrite = () => {
   const [isShowPriceInput, setIsShowPriceInput] = useState(false);
 
+  const [mediaList, setMediaList] = useState([]);
   const [postWriteData, onChangePostWriteData, setPostWriteData] = useInputs({
     location: undefined,
     eventTime: dayjs().format('YYYY-MM-DDTHH:mm'),
@@ -23,6 +24,20 @@ const PostWrite = () => {
   });
 
   const { mutate: PostWriteMutate } = useMutation(postPostWrite);
+
+  const postWriteSubmit = (event) => {
+    event.preventDefault();
+    const formData = new FormData();
+    formData.append('mediaList', mediaList);
+    formData.append(
+      'data',
+      JSON.stringify({
+        ...postWriteData,
+        eventTime: dayjs(postWriteData.eventTime).format('YYYY-MM-DD HH:ss:ss'),
+      })
+    );
+    PostWriteMutate(formData);
+  };
 
   const SetPrivate = () => {
     setPostWriteData((pre) => ({ ...pre, isAnonymous: true }));
@@ -45,110 +60,108 @@ const PostWrite = () => {
     }
   };
 
-  const postWriteSubmit = (event) => {
-    event.preventDefault();
-    PostWriteMutate({
-      data: JSON.stringify({
-        ...postWriteData,
-        eventTime: postWriteData.eventTime.format('YYYY-MM-DD HH:ss:ss'),
-      }),
-    });
-  };
   return (
     <Style.Container>
-      <PostUploadMediaForm />
-      <Style.OccurTimeLayout>
-        <Style.PostWriteTitle>제보 발생 시간</Style.PostWriteTitle>
-        <Style.DatePicker
-          type="datetime-local"
-          name="eventTime"
-          value={postWriteData.eventTime}
-          onChange={onChangePostWriteData}
-        ></Style.DatePicker>
-      </Style.OccurTimeLayout>
+      <form onSubmit={postWriteSubmit}>
+        <PostUploadMediaForm setMediaList={setMediaList} />
+        <Style.OccurTimeLayout>
+          <Style.PostWriteTitle>제보 발생 시간</Style.PostWriteTitle>
+          <Style.DatePicker
+            type="datetime-local"
+            name="eventTime"
+            value={postWriteData.eventTime}
+            onChange={onChangePostWriteData}
+          ></Style.DatePicker>
+        </Style.OccurTimeLayout>
 
-      <Style.LocationLayout>
-        <PostWriteSearchLocation setPostWriteData={setPostWriteData} />
-      </Style.LocationLayout>
+        <Style.LocationLayout>
+          <PostWriteSearchLocation setPostWriteData={setPostWriteData} />
+        </Style.LocationLayout>
 
-      <Style.ContextLayout>
-        <Style.ContextTitleInput
-          type="text"
-          placeholder="제목을 입력하세요"
-          onChange={onChangePostWriteData}
-          name="title"
-        ></Style.ContextTitleInput>
-        <Style.ContextBodyTextArea
-          placeholder="상황을 최대한 상세하게 기록해 주세요&#13;(상황, 시간, 사건 전개과정, 경과상태 등)&#13;&#10;최대 2000자"
-          onChange={onChangePostWriteData}
-          name="content"
-        ></Style.ContextBodyTextArea>
-      </Style.ContextLayout>
+        <Style.ContextLayout>
+          <Style.ContextTitleInput
+            type="text"
+            placeholder="제목을 입력하세요"
+            onChange={onChangePostWriteData}
+            name="title"
+          ></Style.ContextTitleInput>
+          <Style.ContextBodyTextArea
+            placeholder="상황을 최대한 상세하게 기록해 주세요&#13;(상황, 시간, 사건 전개과정, 경과상태 등)&#13;&#10;최대 2000자"
+            onChange={onChangePostWriteData}
+            name="content"
+          ></Style.ContextBodyTextArea>
+        </Style.ContextLayout>
 
-      <Style.PostTypeLayout>
-        <Style.PostWriteTitle>제보 방식</Style.PostWriteTitle>
-        <Style.PostRadioButton
-          onClick={onChangePostWriteData}
-          value="charged"
-          name="postType"
-          radioControl={postWriteData.postType}
-        >
-          유료제보
-        </Style.PostRadioButton>
-        <Style.PostRadioButton
-          onClick={onChangePostWriteData}
-          value="free"
-          name="postType"
-          radioControl={postWriteData.postType}
-        >
-          무료제보
-        </Style.PostRadioButton>
-        <Style.PostRadioButton
-          onClick={onChangePostWriteData}
-          value="exclusive"
-          name="postType"
-          radioControl={postWriteData.postType}
-        >
-          단독제보
-        </Style.PostRadioButton>
-      </Style.PostTypeLayout>
+        <Style.PostTypeLayout>
+          <Style.PostWriteTitle>제보 방식</Style.PostWriteTitle>
+          <Style.PostRadioButton
+            onClick={onChangePostWriteData}
+            type="button"
+            value="charged"
+            name="postType"
+            radioControl={postWriteData.postType}
+          >
+            유료제보
+          </Style.PostRadioButton>
+          <Style.PostRadioButton
+            type="button"
+            onClick={onChangePostWriteData}
+            value="free"
+            name="postType"
+            radioControl={postWriteData.postType}
+          >
+            무료제보
+          </Style.PostRadioButton>
+          <Style.PostRadioButton
+            type="button"
+            onClick={onChangePostWriteData}
+            value="exclusive"
+            name="postType"
+            radioControl={postWriteData.postType}
+          >
+            단독제보
+          </Style.PostRadioButton>
+        </Style.PostTypeLayout>
 
-      <Style.PriceLayout>
-        <Style.PostWriteTitle>제보 가격</Style.PostWriteTitle>
-        <Style.PostPriceInput
-          type="text"
-          onInput={maxLengthCheck}
-          maxLength="15"
-          value={
-            isShowPriceInput
-              ? postWriteData.price
-              : postWriteData.price.toLocaleString('ko-KR') + '원'
-          }
-          onChange={handlePrice}
-          onBlur={toggleShowPirceInput}
-          onFocus={toggleShowPirceInput}
-        ></Style.PostPriceInput>
-      </Style.PriceLayout>
+        <Style.PriceLayout>
+          <Style.PostWriteTitle>제보 가격</Style.PostWriteTitle>
+          <Style.PostPriceInput
+            type="text"
+            onInput={maxLengthCheck}
+            maxLength="15"
+            value={
+              isShowPriceInput
+                ? postWriteData.price
+                : postWriteData.price.toLocaleString('ko-KR') + '원'
+            }
+            onChange={handlePrice}
+            onBlur={toggleShowPirceInput}
+            onFocus={toggleShowPirceInput}
+          ></Style.PostPriceInput>
+        </Style.PriceLayout>
 
-      <Style.AnonymousLayout>
-        <Style.PostWriteTitle>프로필을 공개하시겠습니까?</Style.PostWriteTitle>
-        <Style.PostRadioButton
-          onClick={SetPrivate}
-          value={true}
-          radioControl={postWriteData.isAnonymous}
-        >
-          비공개
-        </Style.PostRadioButton>
-        <Style.PostRadioButton
-          onClick={SetPublic}
-          value={false}
-          radioControl={postWriteData.isAnonymous}
-        >
-          공개
-        </Style.PostRadioButton>
-      </Style.AnonymousLayout>
+        <Style.AnonymousLayout>
+          <Style.PostWriteTitle>
+            프로필을 공개하시겠습니까?
+          </Style.PostWriteTitle>
+          <Style.PostRadioButton
+            onClick={SetPrivate}
+            value={true}
+            radioControl={postWriteData.isAnonymous}
+          >
+            비공개
+          </Style.PostRadioButton>
+          <Style.PostRadioButton
+            onClick={SetPublic}
+            value={false}
+            radioControl={postWriteData.isAnonymous}
+          >
+            공개
+          </Style.PostRadioButton>
+        </Style.AnonymousLayout>
 
-      <Style.PostSubmitButton type="submit">제보 하기</Style.PostSubmitButton>
+        <Style.PostSubmitButton type="submit">제보 하기</Style.PostSubmitButton>
+      </form>
     </Style.Container>
   );
 };

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -67,7 +67,7 @@ const PostWrite = () => {
         ...postWriteData,
         hashtagList: hashtagList === undefined ? null : hashtagList,
         price: postWriteData.postType === 'free' ? 0 : postWriteData.price,
-        eventTime: dayjs(postWriteData.eventTime).format('YYYY-MM-DD HH:ss:ss'),
+        eventTime: dayjs(postWriteData.eventTime).format('YYYY-MM-DD HH:mm:ss'),
       })
     );
     PostWriteMutate(formData);
@@ -83,9 +83,7 @@ const PostWrite = () => {
   const handlePrice = (event) => {
     event.preventDefault();
     let price = Number(event.target.value);
-    if (Number.isNaN(price)) {
-      price = 0;
-    }
+    if (Number.isNaN(price)) return;
     setPostWriteData((pre) => ({
       ...pre,
       price: price,

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -82,7 +82,6 @@ const PostWrite = () => {
           onChange={onChangePostData}
           name="content"
         ></Style.ContextBodyTextArea>
-        <Style.ContextHashTagInput placeholder="#해시태그를 입력하세요. (최대 8개)"></Style.ContextHashTagInput>
       </Style.ContextLayout>
 
       <Style.PostTypeLayout>

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -62,7 +62,9 @@ const PostWrite = () => {
       );
     // 해시태그 추출
 
-    formData.append('mediaList', mediaList);
+    for (let i = 0; i < mediaList.length; i++) {
+      formData.append('mediaList', mediaList[i]);
+    }
     formData.append(
       'data',
       JSON.stringify({

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -74,7 +74,15 @@ const PostWrite = () => {
   };
 
   const handlePrice = (event) => {
-    setPostWriteData((pre) => ({ ...pre, price: Number(event.target.value) }));
+    event.preventDefault();
+    let price = Number(event.target.value);
+    if (Number.isNaN(price)) {
+      price = 0;
+    }
+    setPostWriteData((pre) => ({
+      ...pre,
+      price: price,
+    }));
   };
 
   const toggleShowPirceInput = () => {
@@ -86,7 +94,6 @@ const PostWrite = () => {
       target.value = target.value.slice(0, target.maxLength);
     }
   };
-  console.log(postWriteData);
   return (
     <Style.Container>
       <form onSubmit={postWriteSubmit}>
@@ -164,6 +171,12 @@ const PostWrite = () => {
             onChange={handlePrice}
             onBlur={toggleShowPirceInput}
             onFocus={toggleShowPirceInput}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                event.target.blur();
+              }
+            }}
           ></Style.PostPriceInput>
         </Style.PriceLayout>
 

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -33,6 +33,7 @@ const PostWrite = () => {
       'data',
       JSON.stringify({
         ...postWriteData,
+        price: postWriteData.postType === 'free' ? 0 : postWriteData.price,
         eventTime: dayjs(postWriteData.eventTime).format('YYYY-MM-DD HH:ss:ss'),
       })
     );
@@ -123,7 +124,7 @@ const PostWrite = () => {
           </Style.PostRadioButton>
         </Style.PostTypeLayout>
 
-        <Style.PriceLayout>
+        <Style.PriceLayout postType={postWriteData.postType}>
           <Style.PostWriteTitle>제보 가격</Style.PostWriteTitle>
           <Style.PostPriceInput
             type="text"

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -12,9 +12,8 @@ import { useNavigate } from 'react-router-dom';
 import { PAGE_PATH } from 'constants/path';
 
 const PostWrite = () => {
-  const [isShowPriceInput, setIsShowPriceInput] = useState(false);
   const navigate = useNavigate();
-
+  const [isShowPriceInput, setIsShowPriceInput] = useState(false);
   const [mediaList, setMediaList] = useState([]);
   const [postWriteData, onChangePostWriteData, setPostWriteData] = useInputs({
     location: undefined,
@@ -66,10 +65,10 @@ const PostWrite = () => {
     PostWriteMutate(formData);
   };
 
-  const SetPrivate = () => {
+  const postPrivate = () => {
     setPostWriteData((pre) => ({ ...pre, isAnonymous: true }));
   };
-  const SetPublic = () => {
+  const postPublic = () => {
     setPostWriteData((pre) => ({ ...pre, isAnonymous: false }));
   };
 
@@ -185,14 +184,14 @@ const PostWrite = () => {
             프로필을 공개하시겠습니까?
           </Style.PostWriteTitle>
           <Style.PostRadioButton
-            onClick={SetPrivate}
+            onClick={postPrivate}
             value={true}
             radioControl={postWriteData.isAnonymous}
           >
             비공개
           </Style.PostRadioButton>
           <Style.PostRadioButton
-            onClick={SetPublic}
+            onClick={postPublic}
             value={false}
             radioControl={postWriteData.isAnonymous}
           >

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -52,16 +52,26 @@ const PostWrite = () => {
     }
 
     const formData = new FormData();
+
+    let hashtagList = [];
+    postWriteData.content
+      .split(/(#[^\s#]+|\n)/g)
+      .map(
+        (contentSlice) =>
+          contentSlice[0] === '#' && hashtagList.push(contentSlice)
+      );
+    // 해시태그 추출
+
     formData.append('mediaList', mediaList);
     formData.append(
       'data',
       JSON.stringify({
         ...postWriteData,
+        hashtagList: hashtagList.length === 0 ? 'null' : hashtagList,
         price: postWriteData.postType === 'free' ? 0 : postWriteData.price,
         eventTime: dayjs(postWriteData.eventTime).format('YYYY-MM-DD HH:ss:ss'),
       })
     );
-
     PostWriteMutate(formData);
   };
 

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -53,23 +53,19 @@ const PostWrite = () => {
 
     const formData = new FormData();
 
-    let hashtagList = [];
-    postWriteData.content
-      .split(/(#[^\s#]+|\n)/g)
-      .map(
-        (contentSlice) =>
-          contentSlice[0] === '#' && hashtagList.push(contentSlice)
-      );
-    // 해시태그 추출
+    const hashtagList = postWriteData.content
+      .match(/#[^\s#]+/g)
+      ?.map((hashtag) => hashtag.replace('#', ''));
 
     for (let i = 0; i < mediaList.length; i++) {
       formData.append('mediaList', mediaList[i]);
     }
+
     formData.append(
       'data',
       JSON.stringify({
         ...postWriteData,
-        hashtagList: hashtagList.length === 0 ? 'null' : hashtagList,
+        hashtagList: hashtagList === undefined ? null : hashtagList,
         price: postWriteData.postType === 'free' ? 0 : postWriteData.price,
         eventTime: dayjs(postWriteData.eventTime).format('YYYY-MM-DD HH:ss:ss'),
       })

--- a/breaking-front/src/pages/PostWrite/PostWrite.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.js
@@ -7,9 +7,13 @@ import PostWriteSearchLocation from 'pages/PostWrite/units/PostWriteSearchLocati
 import useInputs from 'hooks/useInputs';
 import { useMutation } from 'react-query';
 import { postPostWrite } from 'api/postWrite';
+import MESSAGE from 'constants/message';
+import { useNavigate } from 'react-router-dom';
+import { PAGE_PATH } from 'constants/path';
 
 const PostWrite = () => {
   const [isShowPriceInput, setIsShowPriceInput] = useState(false);
+  const navigate = useNavigate();
 
   const [mediaList, setMediaList] = useState([]);
   const [postWriteData, onChangePostWriteData, setPostWriteData] = useInputs({
@@ -23,10 +27,31 @@ const PostWrite = () => {
     thumbnailIndex: 0,
   });
 
-  const { mutate: PostWriteMutate } = useMutation(postPostWrite);
+  const { mutate: PostWriteMutate } = useMutation(postPostWrite, {
+    onSuccess: () => {
+      alert('작성되었습니다.');
+      navigate(PAGE_PATH.HOME);
+    },
+    onError: (error) => {
+      console.log(error);
+      //에러처리
+    },
+  });
 
   const postWriteSubmit = (event) => {
     event.preventDefault();
+
+    if (!postWriteData.location) {
+      alert(MESSAGE.POST_WRITE.LOCATION_BLANK);
+      return;
+    } else if (postWriteData.title === '') {
+      alert(MESSAGE.POST_WRITE.TITLE_BLANK);
+      return;
+    } else if (postWriteData.content === '') {
+      alert(MESSAGE.POST_WRITE.CONTENT_BLANK);
+      return;
+    }
+
     const formData = new FormData();
     formData.append('mediaList', mediaList);
     formData.append(
@@ -37,6 +62,7 @@ const PostWrite = () => {
         eventTime: dayjs(postWriteData.eventTime).format('YYYY-MM-DD HH:ss:ss'),
       })
     );
+
     PostWriteMutate(formData);
   };
 
@@ -60,7 +86,7 @@ const PostWrite = () => {
       target.value = target.value.slice(0, target.maxLength);
     }
   };
-
+  console.log(postWriteData);
   return (
     <Style.Container>
       <form onSubmit={postWriteSubmit}>

--- a/breaking-front/src/pages/PostWrite/PostWrite.styles.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.styles.js
@@ -100,6 +100,7 @@ export const PostTypeLayout = styled.div`
 `;
 
 export const PriceLayout = styled.div`
+  display: ${({ postType }) => (postType === 'free' ? 'none' : 'block')};
   margin-top: 40px;
   > * {
     margin-bottom: 30px;

--- a/breaking-front/src/pages/PostWrite/PostWrite.styles.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.styles.js
@@ -89,11 +89,6 @@ export const ContextBodyTextArea = styled.textarea`
   }
 `;
 
-export const ContextHashTagInput = styled(ContextTitleInput)`
-  font-size: 12px;
-  color: ${({ theme }) => theme.blue[900]};
-`;
-
 export const PostTypeLayout = styled.div`
   margin-top: 40px;
   > button {

--- a/breaking-front/src/pages/PostWrite/PostWrite.styles.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.styles.js
@@ -6,8 +6,8 @@ export const PostWriteTitle = styled.h3`
 `;
 
 export const PostRadioButton = styled(Button)`
-  background-color: ${({ id, radioControl, theme }) =>
-    id === radioControl && theme.blue[400]};
+  background-color: ${({ value, radioControl, theme }) =>
+    value === radioControl && theme.blue[400]};
 `;
 
 export const PostSubmitButton = styled(Button)`

--- a/breaking-front/src/pages/PostWrite/PostWrite.styles.js
+++ b/breaking-front/src/pages/PostWrite/PostWrite.styles.js
@@ -31,7 +31,7 @@ export const OccurTimeLayout = styled.div`
 
 export const DatePicker = styled.input`
   position: relative;
-  width: 200px;
+  width: 180px;
   margin-right: 10px;
   padding: 10px;
   border: solid 1px ${({ theme }) => theme.gray[500]};

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
@@ -7,7 +7,7 @@ import PostWriteModal from 'pages/PostWrite/units/PostWriteModal';
 import PropTypes from 'prop-types';
 import parseAddressName from 'utils/parseAddressName';
 
-const PostWriteSearchLocation = ({ setForm }) => {
+const PostWriteSearchLocation = ({ setPostWriteData }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const toggleModal = () => {
@@ -103,12 +103,15 @@ const PostWriteSearchLocation = ({ setForm }) => {
     // parent의 form state를 받아와 결과값을 추가
     setLocationInputValue(markerInformation.addressName);
     setIsModalOpen(false);
-    console.log({
-      latitude: markerInformation.lat,
-      longitude: markerInformation.lng,
-      region: parseAddressName(markerInformation.addressName),
-      address: markerInformation.addressName,
-    });
+    setPostWriteData((pre) => ({
+      ...pre,
+      location: {
+        latitude: markerInformation.lat,
+        longitude: markerInformation.lng,
+        region: parseAddressName(markerInformation.addressName),
+        address: markerInformation.addressName,
+      },
+    }));
   };
 
   useEffect(() => {
@@ -271,7 +274,7 @@ const PostWriteSearchLocation = ({ setForm }) => {
 };
 
 PostWriteSearchLocation.propTypes = {
-  setForm: PropTypes.object,
+  setPostWriteData: PropTypes.func,
 };
 
 export default PostWriteSearchLocation;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
@@ -108,7 +108,7 @@ const PostWriteSearchLocation = ({ setPostWriteData }) => {
       location: {
         latitude: markerInformation.lat,
         longitude: markerInformation.lng,
-        region: parseAddressName(markerInformation.addressName),
+        ...parseAddressName(markerInformation.addressName),
         address: markerInformation.addressName,
       },
     }));
@@ -182,7 +182,6 @@ const PostWriteSearchLocation = ({ setPostWriteData }) => {
                 clickable={true}
                 onClick={locationSubmit}
               />
-              {console.log(markerInformation)}
               <CustomOverlayMap
                 position={{
                   lat: markerInformation.lat,

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.js
@@ -114,6 +114,12 @@ const PostWriteSearchLocation = ({ setPostWriteData }) => {
     }));
   };
 
+  const handleSearchEnterPress = (event) => {
+    if (event.key === 'Enter') {
+      SearchMap(event);
+    }
+  };
+
   useEffect(() => {
     map && map.relayout();
     map &&
@@ -123,6 +129,7 @@ const PostWriteSearchLocation = ({ setPostWriteData }) => {
 
     // modal과 같이 display의 값이 바뀌는 곳에서는  map.relayout() 가 필요
   }, [isModalOpen, map]);
+
   return (
     <>
       <Style.PostWriteTitle>
@@ -228,12 +235,13 @@ const PostWriteSearchLocation = ({ setPostWriteData }) => {
         </Map>
 
         <Style.SearchInformationSideBar>
-          <Style.SearchForm onSubmit={SearchMap}>
+          <Style.SearchForm>
             <Style.SearchInput
               icon={<SearchIcon />}
               onChange={handleSearchInput}
               value={searchContent}
               iconClick={SearchMap}
+              onKeyDown={handleSearchEnterPress}
             />
           </Style.SearchForm>
 

--- a/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteSearchLocation.styles.js
@@ -46,7 +46,7 @@ export const SearchInformationSideBar = styled.div`
   background-color: ${({ theme }) => theme.opacityWhite};
 `;
 
-export const SearchForm = styled.form`
+export const SearchForm = styled.div`
   display: flex;
   padding: 10px;
 `;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
@@ -4,10 +4,10 @@ import { ReactComponent as PlusIcon } from 'assets/svg/Plus.svg';
 import { ReactComponent as LeftArrowIcon } from 'assets/svg/left_arrow_line.svg';
 import { ReactComponent as RightArrowIcon } from 'assets/svg/right_arrow_line.svg';
 import { ReactComponent as XMarkIcon } from 'assets/svg/x_mark.svg';
+import PropTypes from 'prop-types';
 
-const PostUploadMediaForm = () => {
+const PostUploadMediaForm = ({ setMediaList }) => {
   const caruselRef = useRef();
-  const [filesThumbnail, setFilesThumbnail] = useState([]);
   const LeftCaruselClick = () => {
     caruselRef.current.scrollTo({
       left: caruselRef.current.scrollLeft - 500,
@@ -21,15 +21,19 @@ const PostUploadMediaForm = () => {
     });
   };
 
+  const [filesThumbnail, setFilesThumbnail] = useState([]);
+
   const deleteFile = (target) => {
     window.URL.revokeObjectURL(filesThumbnail[target]);
     setFilesThumbnail((pre) => pre.filter((item, index) => index !== target));
+    setMediaList((pre) => pre.filter((item, index) => index !== target));
   };
 
   const handleAddFiles = (fileLists) => {
     if (filesThumbnail.length + fileLists.length > 20) {
       alert('업로드 개수를 초과하였습니다');
     } else {
+      setMediaList((pre) => [...pre, ...fileLists]);
       let fileList = [...filesThumbnail];
       for (let i = 0; i < fileLists.length; i++) {
         const currentFileUrl = URL.createObjectURL(fileLists[i]);
@@ -99,6 +103,10 @@ const PostUploadMediaForm = () => {
       </Style.UploadForm>
     </Style.UploadLayout>
   );
+};
+
+PostUploadMediaForm.propTypes = {
+  setMediaList: PropTypes.func,
 };
 
 export default PostUploadMediaForm;

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
@@ -75,6 +75,7 @@ const PostUploadMediaForm = ({ setMediaList }) => {
           type="file"
           onChange={(event) => handleAddFiles(event.target.files)}
           multiple
+          accept="video/*, image/*"
         />
 
         <Style.UploadPreviewLayout>

--- a/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
+++ b/breaking-front/src/pages/PostWrite/units/PostWriteUploadMediaForm.js
@@ -24,7 +24,7 @@ const PostUploadMediaForm = ({ setMediaList }) => {
   const [filesThumbnail, setFilesThumbnail] = useState([]);
 
   const deleteFile = (target) => {
-    window.URL.revokeObjectURL(filesThumbnail[target]);
+    URL.revokeObjectURL(filesThumbnail[target]);
     setFilesThumbnail((pre) => pre.filter((item, index) => index !== target));
     setMediaList((pre) => pre.filter((item, index) => index !== target));
   };


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #152 

## 예상 리뷰 시간
15-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. 제보방식이 무료면 제보가격 입력창을 숨겼습니다
2. 위치,제목,본문 내용을 입력하지 않을시 에러 창이 띄워집니다.
3. 본문의 해시태그를 추출해서 백엔드에 데이터로 보내집니다.
4. 발생시간 input창이 2개에서 하나로 합쳐졌습니다 그에 따라서 로직이 조금 변경되었습니다.
5. 제보 가격의 input창에서 엔터 클릭시 submit되는 현상을 해결했습니다.
6. 제보 가격에서 문자 입력시에 NaN이 출력되는걸 해결했습니다.
7. 위치 modal에서 keyword로 검색할시에 from을 사용했는데 form안에 form태그를 사용할수 없어서 로직을 변경하였습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
변경사항 없음

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
현재 썸네일은 첫번째 사진/동영상 으로 되어있는데 이걸 선택할수 있게 세부기능들 추가할때 한번 시도해보는것도 좋아 보입니다.
