### PR TITLE
feat: 로그아웃 기능 추가

### DIFF
--- a/breaking-front/src/api/login.js
+++ b/breaking-front/src/api/login.js
@@ -32,3 +32,10 @@ export const postSignInWithGoogle = (token) => {
     data: token,
   });
 };
+
+export const getLogout = () => {
+  return api({
+    method: 'get',
+    url: API_PATH.OAUTH2_SIGNOUT,
+  });
+};

--- a/breaking-front/src/components/Header/Header.js
+++ b/breaking-front/src/components/Header/Header.js
@@ -2,6 +2,7 @@ import React, { useContext, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { UserInformationContext } from 'providers/UserInformationProvider';
 import { PAGE_PATH } from 'constants/path';
+import useLogout from 'hooks/queries/useLogout';
 import Input from 'components/Input/Input';
 import Line from 'components/Line/Line';
 import Toggle from 'components/Toggle/Toggle';
@@ -19,6 +20,7 @@ export default function Header() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
   const userData = useContext(UserInformationContext);
+  const { refetch } = useLogout();
 
   const [searchText, setSearchText] = useState('');
   const [isOpenToggle, setIsOpenToggle] = useState(false);
@@ -42,6 +44,11 @@ export default function Header() {
   const labelClick = (path) => {
     navigate(path);
     setIsOpenToggle(false);
+  };
+
+  const logoutClick = () => {
+    let logoutConfirm = window.confirm('로그아웃 하시겠습니까?');
+    logoutConfirm && refetch();
   };
 
   const handleSubmit = (event) => {
@@ -107,7 +114,7 @@ export default function Header() {
                 labelClick={() => labelClick(PAGE_PATH.PROFILE_EDIT)}
               />
               <Line width="200" />
-              <Style.Logout>로그아웃</Style.Logout>
+              <Style.Logout onClick={logoutClick}>로그아웃</Style.Logout>
             </Toggle>
           )}
         </Style.ProfileToggle>

--- a/breaking-front/src/hooks/queries/useLogout.js
+++ b/breaking-front/src/hooks/queries/useLogout.js
@@ -1,0 +1,20 @@
+import { getLogout } from 'api/login';
+import { PAGE_PATH } from 'constants/path';
+import { useQuery, useQueryClient } from 'react-query';
+import { useNavigate } from 'react-router-dom';
+
+const useLogout = () => {
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  return useQuery(['logout'], getLogout, {
+    enabled: false,
+    onSuccess: () => {
+      alert('로그아웃 되었습니다.');
+      queryClient.resetQueries();
+      navigate(PAGE_PATH.LOGIN);
+    },
+  });
+};
+
+export default useLogout;

--- a/breaking-front/src/hooks/queries/useLogout.js
+++ b/breaking-front/src/hooks/queries/useLogout.js
@@ -11,7 +11,9 @@ const useLogout = () => {
     enabled: false,
     onSuccess: () => {
       alert('로그아웃 되었습니다.');
-      queryClient.resetQueries();
+      localStorage.removeItem('access_token');
+      //refresh 토큰 또한 제거 예정
+      queryClient.clear();
       navigate(PAGE_PATH.LOGIN);
     },
   });

--- a/breaking-front/src/mocks/signInHandlers.js
+++ b/breaking-front/src/mocks/signInHandlers.js
@@ -29,4 +29,8 @@ export const signInHandlers = [
       ctx.json(NORMAL_USER)
     );
   }),
+
+  rest.get(API_PATH.OAUTH2_SIGNOUT, (req, res, ctx) => {
+    return res(ctx.status(200));
+  }),
 ];

--- a/breaking-front/src/providers/UserInformationProvider.js
+++ b/breaking-front/src/providers/UserInformationProvider.js
@@ -7,12 +7,7 @@ import { getJWTvalidation } from 'api/signUp';
 export const UserInformationContext = React.createContext();
 
 const UserInformationProvider = ({ children }) => {
-  const [userInformation, setUserInformation] = useState({
-    userId: null,
-    profileImgURL: '',
-    nickname: '',
-    balance: null,
-  });
+  const [userInformation, setUserInformation] = useState({});
 
   const { data, isSuccess, isError } = useQuery(
     ['initalizeValidUser'],
@@ -22,7 +17,14 @@ const UserInformationProvider = ({ children }) => {
 
   useEffect(() => {
     isSuccess && setUserInformation({ ...data?.data, isLogin: true });
-    isError && setUserInformation((pre) => ({ ...pre, isLogin: false }));
+    isError &&
+      setUserInformation(() => ({
+        userId: null,
+        profileImgURL: '',
+        nickname: '',
+        balance: null,
+        isLogin: false,
+      }));
   }, [data, isError, isSuccess]);
 
   return (


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #160

## 예상 리뷰 시간
3-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
로그아웃 기능을 추가했습니다. 로그아웃 시 `queryClient.resetQueries()`를 하고 로그인 페이지로 넘어가게 됩니다.

UserInformationProvider에서 문제가 있었습니다. 기존의 방식으로 로그아웃 시 isLogin만 false 되고 나머지 유저 정보들은 초기화되지 않았습니다. 
그래서 isError시 직접 초기화를 주었습니다.