### PR TITLE
feat: access token 만료시 refresh token을 이용해 재발급

### DIFF
--- a/breaking-front/src/api/api.js
+++ b/breaking-front/src/api/api.js
@@ -1,5 +1,9 @@
-const { default: axios } = require('axios');
-const { DEVELOPMENT_BASE_URL, PRODUCTION_BASE_URL } = require('constants/path');
+import { axios } from 'axios';
+import {
+  DEVELOPMENT_BASE_URL,
+  PRODUCTION_BASE_URL,
+  API_PATH,
+} from 'constants/path';
 
 const api = axios.create({
   baseURL:
@@ -25,6 +29,41 @@ api.interceptors.request.use(
   },
 
   (error) => {
+    return Promise.reject(error);
+  }
+);
+
+api.interceptors.response.use(
+  (response) => {
+    return response;
+  },
+
+  async (error) => {
+    console.log(error);
+    if (
+      error?.response?.status === 401 &&
+      error?.response?.data?.code === 'BSE002'
+    ) {
+      const accessToken = localStorage.getItem('access_token');
+      const refreshToken = document.cookie.match('refresh_token');
+      try {
+        const token = await axios({
+          method: 'get',
+          url: API_PATH.REISSUE,
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Authorization-Refresh': `Bearer ${refreshToken}`,
+          },
+        });
+        console.log(token);
+        if (token) {
+          localStorage.setItem('access_token', token.headers.authorization);
+        }
+      } catch (error) {
+        console.log(error);
+      }
+    }
+
     return Promise.reject(error);
   }
 );

--- a/breaking-front/src/api/api.js
+++ b/breaking-front/src/api/api.js
@@ -62,7 +62,7 @@ api.interceptors.response.use(
         }
       } catch (error) {
         const navigate = useNavigate();
-        alert('세션이 만료되었습니다 다시 로그인해 주시기 바랍니다.');
+        alert('세션이 만료되었습니다. 다시 로그인해 주시기 바랍니다.');
         navigate(PAGE_PATH.LOGIN);
       }
     }

--- a/breaking-front/src/api/api.js
+++ b/breaking-front/src/api/api.js
@@ -1,9 +1,11 @@
-import { axios } from 'axios';
+import axios from 'axios';
 import {
   DEVELOPMENT_BASE_URL,
   PRODUCTION_BASE_URL,
   API_PATH,
+  PAGE_PATH,
 } from 'constants/path';
+import { useNavigate } from 'react-router-dom';
 
 const api = axios.create({
   baseURL:
@@ -22,7 +24,7 @@ api.interceptors.request.use(
 
     config.headers = {
       'Content-type': 'application/json',
-      Authorization: `Bearer ${accessToken}`,
+      authorization: `Bearer ${accessToken}`,
     };
 
     return config;
@@ -45,27 +47,27 @@ api.interceptors.response.use(
       error?.response?.data?.code === 'BSE002'
     ) {
       const accessToken = localStorage.getItem('access_token');
-      const refreshToken = document.cookie.match('refresh_token');
       try {
+        const originalRequest = error.config;
         const token = await axios({
           method: 'get',
           url: API_PATH.REISSUE,
           headers: {
-            Authorization: `Bearer ${accessToken}`,
-            'Authorization-Refresh': `Bearer ${refreshToken}`,
+            authorization: `Bearer ${accessToken}`,
           },
         });
-        console.log(token);
         if (token) {
           localStorage.setItem('access_token', token.headers.authorization);
+          return api.request(originalRequest);
         }
       } catch (error) {
-        console.log(error);
+        const navigate = useNavigate();
+        alert('세션이 만료되었습니다 다시 로그인해 주시기 바랍니다.');
+        navigate(PAGE_PATH.LOGIN);
       }
     }
 
     return Promise.reject(error);
   }
 );
-
 export default api;

--- a/breaking-front/src/constants/path.js
+++ b/breaking-front/src/constants/path.js
@@ -12,6 +12,7 @@ export const PAGE_PATH = {
 };
 
 export const API_PATH = {
+  REISSUE: '/reissue',
   OAUTH2_SIGNUP: '/oauth2/sign-up',
   OAUTH2_SIGNUP_VALIDATE: (validType, profileData) =>
     `/oauth2/sign-up/validate-${validType}/${profileData}`,

--- a/breaking-front/src/mocks/signInHandlers.js
+++ b/breaking-front/src/mocks/signInHandlers.js
@@ -4,7 +4,18 @@ import { NORMAL_USER } from 'mocks/dummyData/users';
 
 export const signInHandlers = [
   rest.get(API_PATH.OAUTH2_VALIDATE_JWT, (req, res, ctx) => {
-    return res(ctx.json(NORMAL_USER), ctx.status(200));
+    // return res(ctx.json(NORMAL_USER), ctx.status(200));
+    return res(
+      ctx.json({ code: 'BSE002', message: 'Access Token이 만료되었습니다.' }),
+      ctx.status(401)
+    );
+  }),
+
+  rest.get(API_PATH.REISSUE, (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.set({ Authorization: '1231901238102381209' })
+    );
   }),
 
   rest.post(API_PATH.OAUTH2_SIGNIN_KAKAO, (req, res, ctx) => {

--- a/breaking-front/src/mocks/signInHandlers.js
+++ b/breaking-front/src/mocks/signInHandlers.js
@@ -4,16 +4,20 @@ import { NORMAL_USER } from 'mocks/dummyData/users';
 
 export const signInHandlers = [
   rest.get(API_PATH.OAUTH2_VALIDATE_JWT, (req, res, ctx) => {
-    // return res(ctx.json(NORMAL_USER), ctx.status(200));
-    return res(
+    return res.once(
       ctx.json({ code: 'BSE002', message: 'Access Token이 만료되었습니다.' }),
       ctx.status(401)
     );
   }),
 
+  rest.get(API_PATH.OAUTH2_VALIDATE_JWT, (req, res, ctx) => {
+    return res(ctx.json(NORMAL_USER), ctx.status(200));
+  }),
+
   rest.get(API_PATH.REISSUE, (req, res, ctx) => {
     return res(
       ctx.status(200),
+      ctx.cookie('authorization-refresh', '12312312312312312312e'),
       ctx.set({ Authorization: '1231901238102381209' })
     );
   }),
@@ -36,7 +40,11 @@ export const signInHandlers = [
   rest.post(API_PATH.OAUTH2_SIGNIN_GOOGLE, (req, res, ctx) => {
     return res(
       ctx.status(200),
-      ctx.set('Authorization', 'a2bcd412ed1!n32op'),
+      ctx.set('authorization', 'a2bcd412ed1!n32op'),
+      ctx.cookie(
+        'authorization-refresh',
+        'asidjf98u2398ejsoijfd923hersacoiqwh98e'
+      ),
       ctx.json(NORMAL_USER)
     );
   }),

--- a/breaking-front/src/mocks/signInHandlers.js
+++ b/breaking-front/src/mocks/signInHandlers.js
@@ -18,7 +18,7 @@ export const signInHandlers = [
     return res(
       ctx.status(200),
       ctx.cookie('authorization-refresh', '12312312312312312312e'),
-      ctx.set({ Authorization: '1231901238102381209' })
+      ctx.set({ authorization: '1231901238102381209' })
     );
   }),
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #169 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
access token 만료시에 refresh token을 이용하여 다시 재발급 받습니다. axios interceptor를 이용하였습니다.


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
refresh token이 쿠키로 넘어와 실제 구동하는지 테스트는 하지 못하였습니다 #183 이슈로 테스트코드를 짜서 테스트할 예정입니다
