### PR TITLE
refactor: followcard를 재사용하게 만든다.

### DIFF
--- a/breaking-front/src/components/FollowCard/FollowCard.js
+++ b/breaking-front/src/components/FollowCard/FollowCard.js
@@ -16,7 +16,7 @@ export default function FollowCard({
   const theme = useTheme();
   const [isLoading, setIsLoading] = useState(false);
 
-  const UnFollow = () => {
+  const unFollowClick = () => {
     if (!UnFollowMutation.isLoading) {
       UnFollowMutation.mutate(profileData.userId, {
         onSuccess: () => setIsLoading(false),
@@ -25,7 +25,7 @@ export default function FollowCard({
     }
   };
 
-  const Follow = () => {
+  const followClick = () => {
     if (!FollowMutation.isLoading) {
       FollowMutation.mutate(profileData.userId, {
         onSuccess: () => setIsLoading(false),
@@ -50,7 +50,7 @@ export default function FollowCard({
       {isPermission && (
         <Style.DeleteButton
           size="small"
-          onClick={profileData.isFollowing ? UnFollow : Follow}
+          onClick={profileData.isFollowing ? unFollowClick : followClick}
         >
           {isLoading ? (
             <Style.Loading type="spin" color={theme.blue[900]} width="10px" />

--- a/breaking-front/src/components/FollowCard/FollowCard.js
+++ b/breaking-front/src/components/FollowCard/FollowCard.js
@@ -16,6 +16,24 @@ export default function FollowCard({
   const theme = useTheme();
   const [isLoading, setIsLoading] = useState(false);
 
+  const UnFollow = () => {
+    if (!UnFollowMutation.isLoading) {
+      UnFollowMutation.mutate(profileData.userId, {
+        onSuccess: () => setIsLoading(false),
+      });
+      setIsLoading(true);
+    }
+  };
+
+  const Follow = () => {
+    if (!FollowMutation.isLoading) {
+      FollowMutation.mutate(profileData.userId, {
+        onSuccess: () => setIsLoading(false),
+      });
+      setIsLoading(true);
+    }
+  };
+
   return (
     <Style.FollowCard>
       <ProfileImage
@@ -29,44 +47,20 @@ export default function FollowCard({
         </Style.Nickname>
         <Style.StatusMessage>{profileData?.statusMsg}</Style.StatusMessage>
       </Style.Container>
-      {isPermission &&
-        (profileData.isFollowing ? (
-          <Style.DeleteButton
-            size="small"
-            onClick={() => {
-              if (!UnFollowMutation.isLoading) {
-                UnFollowMutation.mutate(profileData.userId, {
-                  onSuccess: () => setIsLoading(false),
-                });
-                setIsLoading(true);
-              }
-            }}
-          >
-            {isLoading ? (
-              <Style.Loading type="spin" color={theme.blue[900]} width="10px" />
-            ) : (
-              '언팔로우'
-            )}
-          </Style.DeleteButton>
-        ) : (
-          <Style.DeleteButton
-            size="small"
-            onClick={() => {
-              if (!FollowMutation.isLoading) {
-                FollowMutation.mutate(profileData.userId, {
-                  onSuccess: () => setIsLoading(false),
-                });
-                setIsLoading(true);
-              }
-            }}
-          >
-            {isLoading ? (
-              <Style.Loading type="spin" color={theme.blue[900]} width="10px" />
-            ) : (
-              '팔로우'
-            )}
-          </Style.DeleteButton>
-        ))}
+      {isPermission && (
+        <Style.DeleteButton
+          size="small"
+          onClick={profileData.isFollowing ? UnFollow : Follow}
+        >
+          {isLoading ? (
+            <Style.Loading type="spin" color={theme.blue[900]} width="10px" />
+          ) : profileData.isFollowing ? (
+            '언팔로우'
+          ) : (
+            '팔로우'
+          )}
+        </Style.DeleteButton>
+      )}
     </Style.FollowCard>
   );
 }

--- a/breaking-front/src/components/FollowCard/FollowCard.js
+++ b/breaking-front/src/components/FollowCard/FollowCard.js
@@ -3,57 +3,19 @@ import PropTypes from 'prop-types';
 import * as Style from 'components/FollowCard/FollowCard.styles';
 import ProfileImage from 'components/ProfileImage/ProfileImage';
 import ImageUrlConverter from 'utils/ImageUrlConverter';
-import { useMutation, useQueryClient } from 'react-query';
-import { deleteUnFollow, postFollow } from 'api/profile';
 import { useTheme } from 'styled-components';
+import { useState } from 'react';
 
 export default function FollowCard({
   profileData,
   isPermission,
   cardClick,
-  setFollowerList,
-  setFollowingList,
+  FollowMutation,
+  UnFollowMutation,
 }) {
   const theme = useTheme();
-  const queryClient = useQueryClient();
-  const ChangeIsFollowField = (pre) => {
-    return pre.map((information) =>
-      information.userId === profileData.userId
-        ? {
-            ...information,
-            isFollowing: !information.isFollowing,
-          }
-        : information
-    );
-  };
-  // follow Following 리스트의 값을 변경해주어야함
+  const [isLoading, setIsLoading] = useState(false);
 
-  const { mutate: UnFollow, isLoading: isUnFollowLoading } = useMutation(
-    deleteUnFollow,
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries('profile');
-        setFollowerList((pre) => ChangeIsFollowField(pre));
-        setFollowingList((pre) => ChangeIsFollowField(pre));
-      },
-      onError: () => {
-        //에러처리
-      },
-    }
-  );
-  const { mutate: Follow, isLoading: isFollowLoading } = useMutation(
-    postFollow,
-    {
-      onSuccess: () => {
-        queryClient.invalidateQueries('profile');
-        setFollowerList((pre) => ChangeIsFollowField(pre));
-        setFollowingList((pre) => ChangeIsFollowField(pre));
-      },
-      onError: () => {
-        //에러처리
-      },
-    }
-  );
   return (
     <Style.FollowCard>
       <ProfileImage
@@ -72,10 +34,15 @@ export default function FollowCard({
           <Style.DeleteButton
             size="small"
             onClick={() => {
-              !isUnFollowLoading && UnFollow(profileData.userId);
+              if (!UnFollowMutation.isLoading) {
+                UnFollowMutation.mutate(profileData.userId, {
+                  onSuccess: () => setIsLoading(false),
+                });
+                setIsLoading(true);
+              }
             }}
           >
-            {isUnFollowLoading ? (
+            {isLoading ? (
               <Style.Loading type="spin" color={theme.blue[900]} width="10px" />
             ) : (
               '언팔로우'
@@ -85,10 +52,15 @@ export default function FollowCard({
           <Style.DeleteButton
             size="small"
             onClick={() => {
-              !isFollowLoading && Follow(profileData.userId);
+              if (!FollowMutation.isLoading) {
+                FollowMutation.mutate(profileData.userId, {
+                  onSuccess: () => setIsLoading(false),
+                });
+                setIsLoading(true);
+              }
             }}
           >
-            {isFollowLoading ? (
+            {isLoading ? (
               <Style.Loading type="spin" color={theme.blue[900]} width="10px" />
             ) : (
               '팔로우'
@@ -103,6 +75,6 @@ FollowCard.propTypes = {
   profileData: PropTypes.object,
   isPermission: PropTypes.bool,
   cardClick: PropTypes.func,
-  setFollowerList: PropTypes.func,
-  setFollowingList: PropTypes.func,
+  FollowMutation: PropTypes.object,
+  UnFollowMutation: PropTypes.object,
 };

--- a/breaking-front/src/pages/Profile/components/FollowCardList/FollowCardList.js
+++ b/breaking-front/src/pages/Profile/components/FollowCardList/FollowCardList.js
@@ -6,6 +6,8 @@ import { PAGE_PATH } from 'constants/path';
 import { UserInformationContext } from 'providers/UserInformationProvider';
 import FollowCard from 'components/FollowCard/FollowCard';
 import PropTypes from 'prop-types';
+import { useMutation, useQueryClient } from 'react-query';
+import { deleteUnFollow, postFollow } from 'api/profile';
 
 const FollowCardList = ({
   isLoading,
@@ -16,6 +18,40 @@ const FollowCardList = ({
 }) => {
   const navigate = useNavigate();
   const userData = useContext(UserInformationContext);
+
+  const queryClient = useQueryClient();
+  const ChangeIsFollowField = (pre, userId) => {
+    return pre.map((information) =>
+      information.userId === userId
+        ? {
+            ...information,
+            isFollowing: !information.isFollowing,
+          }
+        : information
+    );
+  };
+  // follower following 리스트의 핋드 값을 변경해주어야함
+
+  const UnFollowMutation = useMutation(deleteUnFollow, {
+    onSuccess: (data, userId) => {
+      queryClient.invalidateQueries('profile');
+      setFollowerList((pre) => ChangeIsFollowField(pre, userId));
+      setFollowingList((pre) => ChangeIsFollowField(pre, userId));
+    },
+    onError: () => {
+      //에러처리
+    },
+  });
+  const FollowMutation = useMutation(postFollow, {
+    onSuccess: (data, userId) => {
+      queryClient.invalidateQueries('profile');
+      setFollowerList((pre) => ChangeIsFollowField(pre, userId));
+      setFollowingList((pre) => ChangeIsFollowField(pre, userId));
+    },
+    onError: () => {
+      //에러처리
+    },
+  });
 
   return (
     <>
@@ -29,8 +65,8 @@ const FollowCardList = ({
             isPermission={item.userId !== userData.userId}
             profileData={item}
             key={`follow-${item.userId}`}
-            setFollowingList={setFollowingList}
-            setFollowerList={setFollowerList}
+            FollowMutation={FollowMutation}
+            UnFollowMutation={UnFollowMutation}
           />
         ))}
       {isLoading && (

--- a/breaking-front/src/pages/Profile/components/ProfileFollowModal/ProfileFollowModal.js
+++ b/breaking-front/src/pages/Profile/components/ProfileFollowModal/ProfileFollowModal.js
@@ -37,10 +37,23 @@ const ProfileFollowModal = ({
     followerListData,
     FetchNextFollowerList
   );
+
   const { targetRef: followingTargetRef } = useInfiniteScroll(
     followingListData,
     FetchNextFollowingList
   );
+
+  useEffect(() => {
+    if (isFollowerListLoading) {
+      setFollowerList([]);
+    }
+  }, [isFollowerListLoading]);
+
+  useEffect(() => {
+    if (isFollowingListLoading) {
+      setFollowingList([]);
+    }
+  }, [isFollowingListLoading]);
 
   useEffect(() => {
     followingListData &&

--- a/breaking-front/src/pages/Profile/hooks/queries/useFollowerList.js
+++ b/breaking-front/src/pages/Profile/hooks/queries/useFollowerList.js
@@ -3,6 +3,8 @@ import { useInfiniteQuery } from 'react-query';
 
 const useFollowerList = (userId) =>
   useInfiniteQuery(['followerList', userId], getFollowers, {
+    cacheTime: 0,
+    staleTime: 0,
     getNextPageParam: (lastPage) => {
       return lastPage.cursor;
     },

--- a/breaking-front/src/pages/Profile/hooks/queries/useFollowingList.js
+++ b/breaking-front/src/pages/Profile/hooks/queries/useFollowingList.js
@@ -3,6 +3,8 @@ import { useInfiniteQuery } from 'react-query';
 
 const useFollowingList = (userId) =>
   useInfiniteQuery(['followingList', userId], getFollowings, {
+    cacheTime: 0,
+    staleTime: 0,
     getNextPageParam: (lastPage) => {
       return lastPage.cursor;
     },


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #211 

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. followCard에 mutation을 상위 컴포넌트에서 제어하도록 설정하여 followCard는 UI와 받은 hook을 패치하는 역활만 합니다.
2. 테스트 도중 다른 유저의 follow modal에 갔다가 마이페이지 follow modal로 들어왔을시에 데이터가 남아있던 현상을 해결했습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
follow unfollow mutation을 hook으로 분리하려고 하였으나 #208 pr에서 followButton을 따로 컴포넌트로 빼서 사용하여 충돌이 생겨 머지가 되고 새로 pr을 올리겠습니다.
