### PR TITLE
feat: 세부 조회 페이지에서 구매자 리스트 및 좋아요 리스트 Modal 추가

### DIFF
--- a/breaking-front/src/__test__/utils/LikeCount.test.js
+++ b/breaking-front/src/__test__/utils/LikeCount.test.js
@@ -1,0 +1,19 @@
+import LikeCount from 'utils/LikeCount';
+
+describe('LikeCount 테스트', () => {
+  test('좋아요 개수가 undefined면 빈 값을 return한다.', () => {
+    expect(LikeCount(undefined, undefined)).toEqual();
+  });
+  test('좋아요 개수가 0일 때', () => {
+    expect(LikeCount(undefined, 0)).toEqual('좋아요를 눌러보세요.');
+  });
+  test('닉네임이 undefined고 좋아요 개수가 존재할 떄', () => {
+    expect(LikeCount(undefined, 1)).toEqual('1');
+  });
+  test('닉네임이 존재하고 좋아요 개수가 1일 때', () => {
+    expect(LikeCount('주기', 1)).toEqual('주기님이 좋아합니다.');
+  });
+  test('닉네임이 존재하고 좋아요 개수가 2 이상일 때', () => {
+    expect(LikeCount('주기', 10000)).toEqual('주기님 외 9,999명');
+  });
+});

--- a/breaking-front/src/__test__/utils/LikeCount.test.js
+++ b/breaking-front/src/__test__/utils/LikeCount.test.js
@@ -7,7 +7,7 @@ describe('LikeCount 테스트', () => {
   test('좋아요 개수가 0일 때', () => {
     expect(LikeCount(undefined, 0)).toEqual('좋아요를 눌러보세요.');
   });
-  test('닉네임이 undefined고 좋아요 개수가 존재할 떄', () => {
+  test('닉네임이 undefined고 좋아요 개수가 존재할 때', () => {
     expect(LikeCount(undefined, 1)).toEqual('1');
   });
   test('닉네임이 존재하고 좋아요 개수가 1일 때', () => {

--- a/breaking-front/src/api/post.js
+++ b/breaking-front/src/api/post.js
@@ -50,19 +50,19 @@ export const getPostBoughtList = async ({ queryKey, pageParam = 0 }) => {
   });
   return {
     result: data,
-    cursor: data[data.length - 1]?.commentId,
+    cursor: data[data.length - 1]?.cursorId,
   };
 };
 
 export const getPostLikeList = async ({ queryKey, pageParam = 0 }) => {
-  const [, postId] = queryKey;
+  const [, postId, size = 10] = queryKey;
   const { data } = await api({
     method: 'get',
-    url: API_PATH.POST_LIKE_LIST(postId, pageParam),
+    url: API_PATH.POST_LIKE_LIST(postId, pageParam, size),
   });
   return {
     result: data,
-    cursor: data[data.length - 1]?.commentId,
+    cursor: data[data.length - 1]?.cursorId,
   };
 };
 

--- a/breaking-front/src/components/FollowCard/FollowCard.js
+++ b/breaking-front/src/components/FollowCard/FollowCard.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import * as Style from 'components/FollowCard/FollowCard.styles';
 import ProfileImage from 'components/ProfileImage/ProfileImage';
@@ -15,11 +15,15 @@ export default function FollowCard({
 }) {
   const theme = useTheme();
   const [isLoading, setIsLoading] = useState(false);
+  const [isFollowing, setIsFollowing] = useState(profileData.isFollowing);
 
   const unFollowClick = () => {
     if (!UnFollowMutation.isLoading) {
       UnFollowMutation.mutate(profileData.userId, {
-        onSuccess: () => setIsLoading(false),
+        onSuccess: () => {
+          setIsLoading(false);
+          setIsFollowing(false);
+        },
       });
       setIsLoading(true);
     }
@@ -28,11 +32,18 @@ export default function FollowCard({
   const followClick = () => {
     if (!FollowMutation.isLoading) {
       FollowMutation.mutate(profileData.userId, {
-        onSuccess: () => setIsLoading(false),
+        onSuccess: () => {
+          setIsLoading(false);
+          setIsFollowing(true);
+        },
       });
       setIsLoading(true);
     }
   };
+
+  useEffect(() => {
+    setIsFollowing(profileData.isFollowing);
+  }, [profileData]);
 
   return (
     <Style.FollowCard>
@@ -48,18 +59,18 @@ export default function FollowCard({
         <Style.StatusMessage>{profileData?.statusMsg}</Style.StatusMessage>
       </Style.Container>
       {isPermission && (
-        <Style.DeleteButton
+        <Style.FollowButton
           size="small"
-          onClick={profileData.isFollowing ? unFollowClick : followClick}
+          onClick={isFollowing ? unFollowClick : followClick}
         >
           {isLoading ? (
             <Style.Loading type="spin" color={theme.blue[900]} width="10px" />
-          ) : profileData.isFollowing ? (
+          ) : isFollowing ? (
             '언팔로우'
           ) : (
             '팔로우'
           )}
-        </Style.DeleteButton>
+        </Style.FollowButton>
       )}
     </Style.FollowCard>
   );

--- a/breaking-front/src/components/FollowCard/FollowCard.styles.js
+++ b/breaking-front/src/components/FollowCard/FollowCard.styles.js
@@ -27,7 +27,7 @@ export const StatusMessage = styled.p`
   color: ${({ theme }) => theme.gray[700]};
 `;
 
-export const DeleteButton = styled(Button)`
+export const FollowButton = styled(Button)`
   padding: 5px 10px;
   width: 60px;
   height: 20px;

--- a/breaking-front/src/hooks/mutations/useFollow.js
+++ b/breaking-front/src/hooks/mutations/useFollow.js
@@ -1,15 +1,8 @@
 import { postFollow } from 'api/profile';
 import { useMutation } from 'react-query';
 
-const useFollow = ({ onSuccess }) => {
-  return useMutation(postFollow, {
-    onSuccess: () => {
-      onSuccess();
-    },
-    onError: () => {
-      //에러처리
-    },
-  });
+const useFollow = (option) => {
+  return useMutation(postFollow, option);
 };
 
 export default useFollow;

--- a/breaking-front/src/hooks/mutations/useUnFollow.js
+++ b/breaking-front/src/hooks/mutations/useUnFollow.js
@@ -1,15 +1,8 @@
 import { deleteUnFollow } from 'api/profile';
 import { useMutation } from 'react-query';
 
-const useUnFollow = ({ onSuccess }) => {
-  return useMutation(deleteUnFollow, {
-    onSuccess: () => {
-      onSuccess();
-    },
-    onError: () => {
-      //에러처리
-    },
-  });
+const useUnFollow = (option) => {
+  return useMutation(deleteUnFollow, option);
 };
 
 export default useUnFollow;

--- a/breaking-front/src/mocks/postHandlers.js
+++ b/breaking-front/src/mocks/postHandlers.js
@@ -3,20 +3,38 @@ import { rest } from 'msw';
 import { COMMENT_DATA, POST_DATA, REPLY_DATA } from 'mocks/dummyData/contents';
 import {
   FOLLOWING_USER,
+  NORMAL_USER,
   NO_FOLLOW_USER,
   NO_POSTCOUNT_USER,
   NO_PROFILEIMGURL_USER,
   NO_STATUSMSG_USER,
-  USER6,
 } from 'mocks/dummyData/users';
 
-const USER_LIST = [
-  NO_STATUSMSG_USER,
-  NO_PROFILEIMGURL_USER,
-  NO_POSTCOUNT_USER,
-  NO_FOLLOW_USER,
-  FOLLOWING_USER,
-  USER6,
+const userList = [
+  {
+    cursorId: 0,
+    ...NORMAL_USER,
+  },
+  {
+    cursorId: 1,
+    ...NO_STATUSMSG_USER,
+  },
+  {
+    cursorId: 2,
+    ...NO_PROFILEIMGURL_USER,
+  },
+  {
+    cursorId: 3,
+    ...NO_POSTCOUNT_USER,
+  },
+  {
+    cursorId: 4,
+    ...NO_FOLLOW_USER,
+  },
+  {
+    cursorId: 5,
+    ...FOLLOWING_USER,
+  },
 ];
 
 export const postHandlers = [
@@ -33,11 +51,11 @@ export const postHandlers = [
   }),
 
   rest.get(API_PATH.POST_BOUGHT_LIST(':postId'), (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(USER_LIST));
+    return res(ctx.status(200), ctx.delay(1000), ctx.json(userList));
   }),
 
   rest.get(API_PATH.POST_LIKE_LIST(':postId'), (req, res, ctx) => {
-    return res(ctx.status(200), ctx.json(USER_LIST));
+    return res(ctx.status(200), ctx.json(userList));
   }),
 
   rest.delete(API_PATH.POST_DELETE(':postId'), (req, res, ctx) => {

--- a/breaking-front/src/pages/Post/Post.js
+++ b/breaking-front/src/pages/Post/Post.js
@@ -4,6 +4,7 @@ import dayjs from 'dayjs';
 import { UserInformationContext } from 'providers/UserInformationProvider';
 import { PAGE_PATH } from 'constants/path';
 import ImageUrlConverter from 'utils/ImageUrlConverter';
+import LikeCount from 'utils/LikeCount';
 import Tag from 'components/Tag/Tag';
 import Line from 'components/Line/Line';
 import { PostSkeleton } from 'components/Skeleton/Skeleton';
@@ -13,10 +14,12 @@ import ProfileImage from 'components/ProfileImage/ProfileImage';
 import usePost from 'hooks/queries/usePost';
 import usePostLike from 'pages/Post/hooks/mutations/usePostLike';
 import useDeletePostLike from 'pages/Post/hooks/mutations/useDeletePostLike';
+import usePostLikeList from 'pages/Post/hooks/queries/usePostLikeList';
 import Carousel from 'pages/Post/components/Carousel/Carousel';
 import CommentList from 'pages/Post/components/CommentList/CommentList';
 import ContentToggle from 'pages/Post/components/ContentToggle/ContentToggle';
 import PurchaseButton from 'pages/Post/components/PurchaseButton/PurchaseButton';
+import PostLikeListModal from 'pages/Post/components/PostLikeListModal/PostLikeListModal';
 import * as Style from 'pages/Post/Post.styles';
 import { ReactComponent as LocationIcon } from 'assets/svg/location.svg';
 import { ReactComponent as LikeIcon } from 'assets/svg/like.svg';
@@ -27,14 +30,17 @@ import { ReactComponent as ETCIcon } from 'assets/svg/etc.svg';
 const Post = () => {
   let { id: postId } = useParams();
   postId = Number(postId);
+
   const navigate = useNavigate();
   const { userId } = useContext(UserInformationContext);
 
   const [isOpenContentToggle, setIsOpenContentToggle] = useState(false);
+  const [isOpenLikeListModal, setIsOpenLikeListModal] = useState(false);
   const [isLiked, setIsLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
 
   const { data: postData, isLoading: isPostDataLoading } = usePost(postId);
+  const { data: likeUserData } = usePostLikeList(postId, 1);
 
   const { mutate: PostLike } = usePostLike();
   const { mutate: DeletePostLike } = useDeletePostLike();
@@ -49,6 +55,10 @@ const Post = () => {
     setIsLiked((pre) => !pre);
   };
 
+  const toggleLikeListModal = () => {
+    setIsOpenLikeListModal((pre) => !pre);
+  };
+
   const toggleComment = () => {
     setIsOpenContentToggle((pre) => !pre);
   };
@@ -60,6 +70,11 @@ const Post = () => {
 
   return (
     <>
+      <PostLikeListModal
+        isOpen={isOpenLikeListModal}
+        postId={postId}
+        closeClick={toggleLikeListModal}
+      />
       <ScrollToTop />
       <Style.Post>
         {isPostDataLoading ? (
@@ -148,7 +163,16 @@ const Post = () => {
                   <span onClick={toggleLiked}>
                     {isLiked ? <LikedIcon /> : <LikeIcon />}
                   </span>
-                  <span>{likeCount?.toLocaleString('ko-KR')}</span>
+                  <Style.LikeCount
+                    onClick={
+                      likeCount === 0 ? toggleLiked : toggleLikeListModal
+                    }
+                  >
+                    {LikeCount(
+                      likeUserData?.pages[0].result[0]?.nickname,
+                      likeCount
+                    )}
+                  </Style.LikeCount>
                   <div>
                     <CommentIcon />
                     {postData?.data.commentCount.toLocaleString('ko-KR')}

--- a/breaking-front/src/pages/Post/Post.styles.js
+++ b/breaking-front/src/pages/Post/Post.styles.js
@@ -96,8 +96,10 @@ export const ContentCreatedDate = styled(ContentDetail)`
 export const ContentViewCount = styled.span``;
 
 export const ContentPriceContainer = styled.div`
+  display: flex;
   width: 160px;
-  text-align: center;
+  flex-direction: column;
+  align-items: center;
 `;
 
 export const ContentContainer = styled.div`
@@ -134,6 +136,10 @@ export const ContentStatus = styled.div`
     margin-right: 5px;
     vertical-align: middle;
   }
+`;
+
+export const LikeCount = styled.span`
+  cursor: pointer;
 `;
 
 export const Comments = styled.div`

--- a/breaking-front/src/pages/Post/components/PostBoughtListModal/PostBoughtListModal.js
+++ b/breaking-front/src/pages/Post/components/PostBoughtListModal/PostBoughtListModal.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Modal from 'components/Modal/Modal';
+import InfiniteTargetDiv from 'components/InfiniteTargetDiv/InfiniteTargetDiv';
+import useInfiniteScroll from 'hooks/useInfiniteScroll';
+import usePostBoughtList from 'pages/Post/hooks/queries/usePostBoughtList';
+import FollowCard from 'components/FollowCard/FollowCard';
+import { useNavigate } from 'react-router-dom';
+import { PAGE_PATH } from 'constants/path';
+import { FollowCardSkeleton } from 'components/Skeleton/Skeleton';
+import * as Style from 'pages/Post/components/PostBoughtListModal/PostBoughtListModal.styles';
+
+const PostBoughtListModal = ({ postId, isOpen, closeClick }) => {
+  const navigate = useNavigate();
+
+  const {
+    data: boughtListData,
+    isLoading: isBoughtListLoading,
+    isFetching: isBoughtListFetching,
+    fetchNextPage: FetchNextBoughtList,
+  } = usePostBoughtList(postId);
+
+  const { targetRef } = useInfiniteScroll(boughtListData, FetchNextBoughtList);
+
+  return (
+    <Modal isOpen={isOpen} closeClick={closeClick} title="구매자 목록">
+      {boughtListData?.pages.map((page) =>
+        page.result.map((item) => (
+          <FollowCard
+            profileData={item}
+            cardClick={() => navigate(PAGE_PATH.PROFILE(item.userId))}
+            isPermission={false}
+            key={`user-${item.userId}`}
+          />
+        ))
+      )}
+      {isBoughtListLoading && (
+        <>
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+        </>
+      )}
+      <Style.TargetDivWrapper>
+        <InfiniteTargetDiv
+          targetRef={targetRef}
+          isFetching={isBoughtListFetching}
+          height="60px"
+        />
+      </Style.TargetDivWrapper>
+    </Modal>
+  );
+};
+
+PostBoughtListModal.propTypes = {
+  postId: PropTypes.number,
+  isOpen: PropTypes.bool,
+  closeClick: PropTypes.func,
+};
+
+export default PostBoughtListModal;

--- a/breaking-front/src/pages/Post/components/PostBoughtListModal/PostBoughtListModal.styles.js
+++ b/breaking-front/src/pages/Post/components/PostBoughtListModal/PostBoughtListModal.styles.js
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const TargetDivWrapper = styled.div`
+  grid-column-start: span 2;
+`;

--- a/breaking-front/src/pages/Post/components/PostLikeListModal/PostLikeListModal.js
+++ b/breaking-front/src/pages/Post/components/PostLikeListModal/PostLikeListModal.js
@@ -1,0 +1,73 @@
+import React, { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { useNavigate } from 'react-router-dom';
+import useFollow from 'hooks/mutations/useFollow';
+import useUnFollow from 'hooks/mutations/useUnFollow';
+import Modal from 'components/Modal/Modal';
+import InfiniteTargetDiv from 'components/InfiniteTargetDiv/InfiniteTargetDiv';
+import { FollowCardSkeleton } from 'components/Skeleton/Skeleton';
+import usePostLikeList from 'pages/Post/hooks/queries/usePostLikeList';
+import FollowCard from 'components/FollowCard/FollowCard';
+import { PAGE_PATH } from 'constants/path';
+import useInfiniteScroll from 'hooks/useInfiniteScroll';
+import * as Style from 'pages/Post/components/PostLikeListModal/PostLikeListModal.styles';
+import { UserInformationContext } from 'providers/UserInformationProvider';
+
+const PostLikeListModal = ({ postId, isOpen, closeClick }) => {
+  const navigate = useNavigate();
+  const userData = useContext(UserInformationContext);
+
+  const {
+    data: likeListData,
+    isLoading: isLikeListLoading,
+    isFetching: isLikeListFetching,
+    fetchNextPage: FetchNextBoughtList,
+  } = usePostLikeList(postId, 10);
+
+  const followMutation = useFollow();
+  const unFollowMutation = useUnFollow();
+
+  const { targetRef } = useInfiniteScroll(likeListData, FetchNextBoughtList);
+
+  return (
+    <Modal isOpen={isOpen} closeClick={closeClick} title="좋아요">
+      {likeListData?.pages.map((page) =>
+        page.result.map((item) => (
+          <FollowCard
+            profileData={item}
+            cardClick={() => navigate(PAGE_PATH.PROFILE(item.userId))}
+            isPermission={item.userId !== userData.userId}
+            FollowMutation={followMutation}
+            UnFollowMutation={unFollowMutation}
+            key={`user-${item.userId}`}
+          />
+        ))
+      )}
+      {isLikeListLoading && (
+        <>
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+          <FollowCardSkeleton />
+        </>
+      )}
+      <Style.TargetDivWrapper>
+        <InfiniteTargetDiv
+          targetRef={targetRef}
+          isFetching={isLikeListFetching}
+          height="60px"
+        />
+      </Style.TargetDivWrapper>
+    </Modal>
+  );
+};
+
+PostLikeListModal.propTypes = {
+  postId: PropTypes.number,
+  isOpen: PropTypes.bool,
+  closeClick: PropTypes.func,
+};
+
+export default PostLikeListModal;

--- a/breaking-front/src/pages/Post/components/PostLikeListModal/PostLikeListModal.styles.js
+++ b/breaking-front/src/pages/Post/components/PostLikeListModal/PostLikeListModal.styles.js
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const TargetDivWrapper = styled.div`
+  grid-column-start: span 2;
+`;

--- a/breaking-front/src/pages/Post/components/PurchaseButton/PurchaseButton.js
+++ b/breaking-front/src/pages/Post/components/PurchaseButton/PurchaseButton.js
@@ -1,17 +1,35 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Button from 'components/Button/Button';
 import usePostBuy from 'pages/Post/hooks/mutations/usePostBuy';
+import PostBoughtListModal from 'pages/Post/components/PostBoughtListModal/PostBoughtListModal';
 
 const PurchaseButton = ({ postId, isMyPost, isPurchased, isPurchasable }) => {
+  const [isOpenBoughtListModal, setIsOpenBoughtListModal] = useState(false);
   const { mutate: PostBuy } = usePostBuy();
+
+  const toggleBoughtListModal = () => {
+    setIsOpenBoughtListModal((pre) => !pre);
+  };
 
   const postBuyClick = () => {
     const postBuyConfirm = window.confirm('게시글을 구매하시겠습니까?');
     postBuyConfirm && PostBuy(postId);
   };
 
-  if (isMyPost) return <Button color="primary">구매자 목록</Button>;
+  if (isMyPost)
+    return (
+      <>
+        <PostBoughtListModal
+          postId={postId}
+          isOpen={isOpenBoughtListModal}
+          closeClick={toggleBoughtListModal}
+        />
+        <Button color="primary" onClick={toggleBoughtListModal}>
+          구매자 목록
+        </Button>
+      </>
+    );
   else if (isPurchased) return <Button color="primary">다운로드</Button>;
   else if (!isPurchasable)
     return (

--- a/breaking-front/src/pages/Post/hooks/queries/usePostBoughtList.js
+++ b/breaking-front/src/pages/Post/hooks/queries/usePostBoughtList.js
@@ -1,9 +1,11 @@
 import { getPostBoughtList } from 'api/post';
-import { useQuery } from 'react-query';
+import { useInfiniteQuery } from 'react-query';
 
 const usePostBoughtList = (postId) => {
-  return useQuery(['boughtUserList', postId], getPostBoughtList, {
-    enabled: false,
+  return useInfiniteQuery(['postBoughtList', postId], getPostBoughtList, {
+    getNextPageParam: (lastPage) => {
+      return lastPage.cursor;
+    },
   });
 };
 

--- a/breaking-front/src/pages/Post/hooks/queries/usePostLikeList.js
+++ b/breaking-front/src/pages/Post/hooks/queries/usePostLikeList.js
@@ -1,0 +1,12 @@
+import { getPostLikeList } from 'api/post';
+import { useInfiniteQuery } from 'react-query';
+
+const usePostLikeList = (postId, size) => {
+  return useInfiniteQuery(['postLikeList', postId, size], getPostLikeList, {
+    getNextPageParam: (lastPage) => {
+      return lastPage.cursor;
+    },
+  });
+};
+
+export default usePostLikeList;

--- a/breaking-front/src/utils/LikeCount.js
+++ b/breaking-front/src/utils/LikeCount.js
@@ -1,0 +1,9 @@
+const LikeCount = (nickname, likeCount) => {
+  if (likeCount === undefined) return;
+  if (likeCount === 0) return '좋아요를 눌러보세요.';
+  else if (nickname === undefined) return likeCount.toLocaleString('ko-KR');
+  else if (likeCount === 1) return `${nickname}님이 좋아합니다.`;
+  else return `${nickname}님 외 ${(likeCount - 1).toLocaleString('ko-KR')}명`;
+};
+
+export default LikeCount;


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #162
close #188

## 예상 리뷰 시간
25-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
좋아요리스트 Modal은 좋아요 아이콘 오른쪽에 텍스트를 클릭하면 모달이 띄워집니다.

좋아요 0 - '좋아요를 눌러보세요.'

좋아요 1
1. 좋아요 0인 상태에서 유저가 좋아요했을 때 1로 바뀜
2. 첫 렌더링 시 좋아요가 1인 상태이면 '00님이 좋아합니다.'

좋아요 2 이상 - '00님 외 X명'

- 좋아요리스트 모달 컴포넌트 구현
- 구매자리스트 모달 컴포넌트 구현
- PurchaseButton 컴포넌트 구현
- LikeList util 구현
- FollowCard 컴포넌트에 isFollowing state 추가
- useFollow, useUnFollow hook에 onSuccess 대신 option props 추가
