### PR TITLE
feat: PrivateRoute 구현 및 적용

### DIFF
--- a/breaking-front/src/App.js
+++ b/breaking-front/src/App.js
@@ -73,12 +73,12 @@ function App() {
                     element={<SearchUser />}
                   />
                   <Route path={PAGE_PATH.POST(':id')} element={<Post />} />
+                  <Route
+                    path={PAGE_PATH.PROFILE(':id')}
+                    element={<Profile />}
+                  />
 
                   <Route element={<PrivateRoute />}>
-                    <Route
-                      path={PAGE_PATH.PROFILE(':id')}
-                      element={<Profile />}
-                    />
                     <Route
                       path={PAGE_PATH.PROFILE_EDIT}
                       element={<ProfileEdit />}

--- a/breaking-front/src/App.js
+++ b/breaking-front/src/App.js
@@ -24,13 +24,14 @@ import SearchUnified from 'pages/Search/SearchUnified/SearchUnified';
 import SearchPost from 'pages/Search/SearchPost/SearchPost';
 import SearchHashtag from 'pages/Search/SearchHashtag/SearchHashtag';
 import SearchUser from 'pages/Search/SearchUser/SearchUser';
-
+import PrivateRoute from 'PrivateRoute';
 function App() {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { refetchOnWindowFocus: false },
     },
   });
+
   return (
     <GoogleOAuthProvider clientId={process.env.REACT_APP_GOOGLE_CLIENT_KEY}>
       <QueryClientProvider client={queryClient}>
@@ -41,7 +42,15 @@ function App() {
               <Layout>
                 <Routes>
                   <Route path={PAGE_PATH.HOME} element={<MainFeed />} />
-                  <Route path={PAGE_PATH.LOGIN} element={<SocialLogin />} />
+                  <Route
+                    path={PAGE_PATH.LOGIN}
+                    element={
+                      <PrivateRoute redirectPath={PAGE_PATH.HOME} restricted>
+                        <SocialLogin />
+                      </PrivateRoute>
+                    }
+                  />
+                  <Route path={PAGE_PATH.SIGNUP} element={<SignUp />} />
                   <Route
                     path={PAGE_PATH.KAKAO_LOGIN}
                     element={<KakaoRedirect />}
@@ -50,22 +59,6 @@ function App() {
                     path={PAGE_PATH.GOOGLE_LOGIN}
                     element={<GoogleRedirect />}
                   />
-                  <Route path={PAGE_PATH.SIGNUP} element={<SignUp />} />
-                  <Route
-                    path={PAGE_PATH.PROFILE(':id')}
-                    element={<Profile />}
-                  />
-                  <Route
-                    path={PAGE_PATH.PROFILE_EDIT}
-                    element={<ProfileEdit />}
-                  />
-                  <Route path={PAGE_PATH.POST(':id')} element={<Post />} />
-                  <Route path={PAGE_PATH.POST_WRITE} element={<PostWrite />} />
-                  <Route
-                    path={PAGE_PATH.POST_EDIT(':id')}
-                    element={<PostEdit />}
-                  />
-                  <Route path={PAGE_PATH.FINANCIAL} element={<Financial />} />
                   <Route path={PAGE_PATH.SEARCH} element={<SearchUnified />} />
                   <Route
                     path={PAGE_PATH.SEARCH_POST}
@@ -79,6 +72,27 @@ function App() {
                     path={PAGE_PATH.SEARCH_USER}
                     element={<SearchUser />}
                   />
+                  <Route path={PAGE_PATH.POST(':id')} element={<Post />} />
+
+                  <Route element={<PrivateRoute />}>
+                    <Route
+                      path={PAGE_PATH.PROFILE(':id')}
+                      element={<Profile />}
+                    />
+                    <Route
+                      path={PAGE_PATH.PROFILE_EDIT}
+                      element={<ProfileEdit />}
+                    />
+                    <Route
+                      path={PAGE_PATH.POST_WRITE}
+                      element={<PostWrite />}
+                    />
+                    <Route
+                      path={PAGE_PATH.POST_EDIT(':id')}
+                      element={<PostEdit />}
+                    />
+                    <Route path={PAGE_PATH.FINANCIAL} element={<Financial />} />
+                  </Route>
                 </Routes>
               </Layout>
             </UserInformationProvider>

--- a/breaking-front/src/PrivateRoute.js
+++ b/breaking-front/src/PrivateRoute.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Navigate, Outlet } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { PAGE_PATH } from 'constants/path';
+
+const PrivateRoute = ({
+  redirectPath = PAGE_PATH.LOGIN,
+  restricted,
+  children,
+}) => {
+  const accessToken = localStorage.getItem('access_token');
+
+  if (!accessToken && !restricted) {
+    alert('로그인이 필요합니다.');
+    return <Navigate to={redirectPath} replace />;
+  }
+
+  if (accessToken && restricted) return <Navigate to={redirectPath} replace />;
+
+  return children ? children : <Outlet />;
+};
+
+PrivateRoute.propTypes = {
+  redirectPath: PropTypes.string,
+  restricted: PropTypes.bool,
+  children: PropTypes.node,
+};
+
+export default PrivateRoute;

--- a/breaking-front/src/PrivateRoute.js
+++ b/breaking-front/src/PrivateRoute.js
@@ -1,21 +1,22 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import { PAGE_PATH } from 'constants/path';
+import { UserInformationContext } from 'providers/UserInformationProvider';
 
 const PrivateRoute = ({
   redirectPath = PAGE_PATH.LOGIN,
   restricted,
   children,
 }) => {
-  const accessToken = localStorage.getItem('access_token');
+  const { isLogin } = useContext(UserInformationContext);
 
-  if (!accessToken && !restricted) {
+  if (!isLogin && !restricted) {
     alert('로그인이 필요합니다.');
     return <Navigate to={redirectPath} replace />;
   }
 
-  if (accessToken && restricted) return <Navigate to={redirectPath} replace />;
+  if (isLogin && restricted) return <Navigate to={redirectPath} replace />;
 
   return children ? children : <Outlet />;
 };

--- a/breaking-front/src/pages/SignUp/SignUp.js
+++ b/breaking-front/src/pages/SignUp/SignUp.js
@@ -1,32 +1,38 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { PAGE_PATH } from 'constants/path';
 import ProfileSettingForm from 'components/ProfileSettingForm/ProfileSettingForm';
 import MESSAGE from 'constants/message';
 import useSignUp from 'pages/SignUp/hooks/mutations/useSignUp';
+import { UserInformationContext } from 'providers/UserInformationProvider';
 
 const SignUp = () => {
   const navigate = useNavigate();
   const location = useLocation();
+  const { isLogin } = useContext(UserInformationContext);
 
   const { mutate: SignUpMutate, isLoading: isSignUpLoading } = useSignUp();
 
   useEffect(() => {
-    //유저가 sns 로그인하지않고 회원가입 페이지로 들어왔을 때 처리
     if (!location.state) {
-      alert(MESSAGE.SIGNUP.WRONG_ACCESS);
-      navigate(PAGE_PATH.LOGIN);
+      if (isLogin) navigate(PAGE_PATH.HOME);
+      else {
+        alert(MESSAGE.SIGNUP.WRONG_ACCESS);
+        navigate(PAGE_PATH.LOGIN);
+      }
     }
   }, []);
 
   return (
     <>
-      <ProfileSettingForm
-        pageType="signUp"
-        username={location.state?.username}
-        isProfileMutateLoading={isSignUpLoading}
-        mutate={SignUpMutate}
-      />
+      {location.state && (
+        <ProfileSettingForm
+          pageType="signUp"
+          username={location.state.username}
+          isProfileMutateLoading={isSignUpLoading}
+          mutate={SignUpMutate}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #210

## 예상 리뷰 시간
5-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
Private Route을 구현 후 적용했습니다.

로그인한 유저만 접근 가능한 페이지
1. 게시글 작성 페이지
2. 게시글 수정 페이지
3. 프로필 수정 페이지
4. 입출금 페이지

로그인한 유저가 접근 불가능한 페이지
1. 로그인 페이지
2. 회원가입 페이지

SignUp 페이지에서 location.state가 존재하지 않으면 로그인페이지에서 넘어오지 않고 비정상적인 접근으로 판단했고,
 context의 isLogin이 false면 로그인 창으로, true면 메인 창으로 이동합니다.

추가 또는 수정해야할 사항이 있다면 말씀해주시기 바랍니다!