### PR TITLE
feat: 검색 결과 페이지에 searchfilter를 추가한다.

### DIFF
--- a/breaking-front/src/api/search.js
+++ b/breaking-front/src/api/search.js
@@ -14,10 +14,10 @@ export const getSearch = async ({ queryKey, pageParam = 0 }) => {
 };
 
 export const getSearchHashtag = async ({ queryKey, pageParam = 0 }) => {
-  const [, content, size = 10] = queryKey;
+  const [, { content, size = 10, sort, option }] = queryKey;
   const { data } = await api({
     method: 'get',
-    url: API_PATH.SEARCH_HASHTAG(content, size, pageParam),
+    url: API_PATH.SEARCH_HASHTAG(content, size, pageParam, sort, option),
   });
   return {
     result: data,

--- a/breaking-front/src/api/search.js
+++ b/breaking-front/src/api/search.js
@@ -2,10 +2,10 @@ import { API_PATH } from 'constants/path';
 import api from 'api/api';
 
 export const getSearch = async ({ queryKey, pageParam = 0 }) => {
-  const [, content, size = 10] = queryKey;
+  const [, { content, size = 10, sort, option }] = queryKey;
   const { data } = await api({
     method: 'get',
-    url: API_PATH.SEARCH(content, size, pageParam),
+    url: API_PATH.SEARCH(content, size, pageParam, sort, option),
   });
   return {
     result: data,

--- a/breaking-front/src/components/SearchFilter/SearchFilter.js
+++ b/breaking-front/src/components/SearchFilter/SearchFilter.js
@@ -4,7 +4,13 @@ import Filter from 'components/Filter/Filter';
 import * as Style from 'components/SearchFilter/SearchFilter.styles';
 import { useQueryClient } from 'react-query';
 
-export default function SearchFilter({ setSort, option, setOption, queryKey }) {
+export default function SearchFilter({
+  setSort,
+  option,
+  setOption,
+  queryKey,
+  ...props
+}) {
   const queryClient = useQueryClient();
 
   const handleFilter = (sortType) => {
@@ -18,7 +24,7 @@ export default function SearchFilter({ setSort, option, setOption, queryKey }) {
   };
 
   return (
-    <Style.FilterContainer>
+    <Style.FilterContainer {...props}>
       <Filter>
         <Filter.FilterDetail
           onClick={() => {

--- a/breaking-front/src/constants/path.js
+++ b/breaking-front/src/constants/path.js
@@ -92,8 +92,14 @@ export const API_PATH = {
     `/search/user?search=${content}&cursor=${cursor}&size=${size}`,
   SEARCH_HASHTAG: (content, size = 10, cursor) =>
     `/feed?hashtag=${content}&cursor=${cursor}&size=${size}`,
-  SEARCH: (content, size = 10, cursor) =>
-    `/feed?search=${content}&cursor=${cursor}&size=${size}`,
+  SEARCH: (
+    content,
+    size = 10,
+    cursor,
+    sort = 'chronological',
+    option = 'all'
+  ) =>
+    `/feed?search=${content}&cursor=${cursor}&size=${size}&sort=${sort}&sold-option=${option}`,
   BREAKING_MISSION: '/breaking-mission',
   BREAKING_SPOT: '/breaking-spot',
 };

--- a/breaking-front/src/constants/path.js
+++ b/breaking-front/src/constants/path.js
@@ -90,8 +90,14 @@ export const API_PATH = {
   POST_COMMENT_LIKE_DELETE: (commentId) => `/post/comment/${commentId}/like`,
   SEARCH_USER: (content, size = 10, cursor) =>
     `/search/user?search=${content}&cursor=${cursor}&size=${size}`,
-  SEARCH_HASHTAG: (content, size = 10, cursor) =>
-    `/feed?hashtag=${content}&cursor=${cursor}&size=${size}`,
+  SEARCH_HASHTAG: (
+    content,
+    size = 10,
+    cursor,
+    sort = 'chronological',
+    option = 'all'
+  ) =>
+    `/feed?hashtag=${content}&cursor=${cursor}&size=${size}&sort=${sort}&sold-option=${option}`,
   SEARCH: (
     content,
     size = 10,

--- a/breaking-front/src/hooks/useInfiniteScroll.js
+++ b/breaking-front/src/hooks/useInfiniteScroll.js
@@ -17,6 +17,7 @@ const useInfiniteScroll = (data, FetchNextPage) => {
     if (!data) FetchNextPage();
 
     if (targetRef.current) observer.observe(targetRef.current);
+    return () => observer && observer.disconnect();
   }, [data]);
 
   return { targetRef };

--- a/breaking-front/src/pages/Search/SearchHashtag/SearchHashtag.js
+++ b/breaking-front/src/pages/Search/SearchHashtag/SearchHashtag.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import * as Style from 'pages/Search/SearchHashtag/SearchHashtag.styles';
 import SearchHeader from 'pages/Search/components/SearchHeader/SearchHeader';
 import Feed from 'components/Feed/Feed';
@@ -14,12 +14,15 @@ const SearchHashtag = () => {
   const { userId } = useContext(UserInformationContext);
   const currentQuery = useConvertURLQuery();
 
+  const [sort, setSort] = useState('chronological');
+  const [option, setOption] = useState('all');
+
   const {
     data: searchHashtagResult,
     isLoading: searchHashtagLoading,
     fetchNextPage: FetchNextSearchHashtag,
     isFetching: isFetchSearchHashtag,
-  } = useSearchHashtag(currentQuery, 10);
+  } = useSearchHashtag(currentQuery, 10, sort, option);
 
   const { targetRef } = useInfiniteScroll(
     searchHashtagResult,
@@ -28,7 +31,12 @@ const SearchHashtag = () => {
   return (
     <>
       <SearchHeader focusTab={2} />
-
+      <Style.PostFilter
+        setSort={setSort}
+        option={option}
+        setOption={setOption}
+        queryKey="search"
+      />
       {searchHashtagLoading && (
         <Style.PostResultList>
           <FeedSkeleton />

--- a/breaking-front/src/pages/Search/SearchHashtag/SearchHashtag.styles.js
+++ b/breaking-front/src/pages/Search/SearchHashtag/SearchHashtag.styles.js
@@ -1,3 +1,4 @@
+import SearchFilter from 'components/SearchFilter/SearchFilter';
 import styled from 'styled-components';
 
 export const PostResultList = styled.div`
@@ -11,4 +12,8 @@ export const PostResultList = styled.div`
 export const NoDataContainer = styled.div`
   position: relative;
   height: 50vh;
+`;
+
+export const PostFilter = styled(SearchFilter)`
+  margin-top: 30px;
 `;

--- a/breaking-front/src/pages/Search/SearchPost/SearchPost.js
+++ b/breaking-front/src/pages/Search/SearchPost/SearchPost.js
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useState } from 'react';
 import * as Style from 'pages/Search/SearchPost/SearchPost.styles';
 import SearchHeader from 'pages/Search/components/SearchHeader/SearchHeader';
 import Feed from 'components/Feed/Feed';
@@ -14,21 +14,30 @@ const SearchPost = () => {
   const { userId } = useContext(UserInformationContext);
   const currentQuery = useConvertURLQuery();
 
+  const [sort, setSort] = useState('chronological');
+  const [option, setOption] = useState('all');
+
   const {
     data: searchPostResult,
     isLoading: searchPostLoading,
     fetchNextPage: FetchNextSearchPost,
     isFetching: isFetchSearchPost,
-  } = useSearch(currentQuery, 10);
+  } = useSearch(currentQuery, 10, sort, option);
 
   const { targetRef } = useInfiniteScroll(
     searchPostResult,
     FetchNextSearchPost
   );
-
   return (
     <>
       <SearchHeader focusTab={1} />
+
+      <Style.PostFilter
+        setSort={setSort}
+        option={option}
+        setOption={setOption}
+        queryKey="search"
+      />
       {searchPostLoading && (
         <Style.PostResultList>
           <FeedSkeleton />

--- a/breaking-front/src/pages/Search/SearchPost/SearchPost.styles.js
+++ b/breaking-front/src/pages/Search/SearchPost/SearchPost.styles.js
@@ -1,3 +1,4 @@
+import SearchFilter from 'components/SearchFilter/SearchFilter';
 import styled from 'styled-components';
 
 export const PostResultList = styled.div`
@@ -11,4 +12,8 @@ export const PostResultList = styled.div`
 export const NoDataContainer = styled.div`
   position: relative;
   height: 50vh;
+`;
+
+export const PostFilter = styled(SearchFilter)`
+  margin-top: 30px;
 `;

--- a/breaking-front/src/pages/Search/hooks/queries/useSearch.js
+++ b/breaking-front/src/pages/Search/hooks/queries/useSearch.js
@@ -1,10 +1,8 @@
 import { getSearch } from 'api/search';
 import { useInfiniteQuery } from 'react-query';
 
-const useSearch = (content, size) =>
-  useInfiniteQuery(['search', content, size], getSearch, {
-    cacheTime: 0,
-    staleTime: 0,
+const useSearch = (content, size, sort, option) =>
+  useInfiniteQuery(['search', { content, size, sort, option }], getSearch, {
     getNextPageParam: (lastPage) => {
       return lastPage.cursor;
     },

--- a/breaking-front/src/pages/Search/hooks/queries/useSearch.js
+++ b/breaking-front/src/pages/Search/hooks/queries/useSearch.js
@@ -3,6 +3,8 @@ import { useInfiniteQuery } from 'react-query';
 
 const useSearch = (content, size, sort, option) =>
   useInfiniteQuery(['search', { content, size, sort, option }], getSearch, {
+    staleTime: 0,
+    cacheTime: 0,
     getNextPageParam: (lastPage) => {
       return lastPage.cursor;
     },

--- a/breaking-front/src/pages/Search/hooks/queries/useSearchHashtag.js
+++ b/breaking-front/src/pages/Search/hooks/queries/useSearchHashtag.js
@@ -6,6 +6,8 @@ const useSearchHashtag = (content, size, sort, option) =>
     ['searchHashtag', { content, size, sort, option }],
     getSearchHashtag,
     {
+      staleTime: 0,
+      cacheTime: 0,
       getNextPageParam: (lastPage) => {
         return lastPage.cursor;
       },

--- a/breaking-front/src/pages/Search/hooks/queries/useSearchHashtag.js
+++ b/breaking-front/src/pages/Search/hooks/queries/useSearchHashtag.js
@@ -1,12 +1,14 @@
 import { getSearchHashtag } from 'api/search';
 import { useInfiniteQuery } from 'react-query';
 
-const useSearchHashtag = (content, size) =>
-  useInfiniteQuery(['searchHashtag', content, size], getSearchHashtag, {
-    cacheTime: 0,
-    staleTime: 0,
-    getNextPageParam: (lastPage) => {
-      return lastPage.cursor;
-    },
-  });
+const useSearchHashtag = (content, size, sort, option) =>
+  useInfiniteQuery(
+    ['searchHashtag', { content, size, sort, option }],
+    getSearchHashtag,
+    {
+      getNextPageParam: (lastPage) => {
+        return lastPage.cursor;
+      },
+    }
+  );
 export default useSearchHashtag;

--- a/breaking-front/src/pages/Search/hooks/queries/useSearchUser.js
+++ b/breaking-front/src/pages/Search/hooks/queries/useSearchUser.js
@@ -3,8 +3,8 @@ import { useInfiniteQuery } from 'react-query';
 
 const useSearchUser = (content, size) =>
   useInfiniteQuery(['searchUser', content, size], getSearchUser, {
-    cacheTime: 0,
     staleTime: 0,
+    cacheTime: 0,
     getNextPageParam: (lastPage) => {
       return lastPage.cursor;
     },


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #222 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
1. searchFilter를 추가하였습니다
2. searchFilter 컴포넌트의 props를 추가했습니다
3. search query hook의 cachetime을 0으로 초기화하였습니다.
4. observer에 clean up 함수를 추가하였습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/49224104/187030317-465c5d34-9889-449b-b92e-68b947df8ed0.png)

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
2번인 props추가는 styled component에서 새로 만들시에 컴포넌트의 props가 지정이 되어있지 않으면 적용이 되질 않았습니다.
4번은 cleanup 함수가 없을시에 마지막 infinite scroll 이 2번 발생합니다 의미 없는 api 호출이기 때문에 clean up함수를 사용하였습니다.

