### PR TITLE
feat: breaking map page UI 생성

### DIFF
--- a/breaking-front/src/App.js
+++ b/breaking-front/src/App.js
@@ -26,7 +26,7 @@ import SearchHashtag from 'pages/Search/SearchHashtag/SearchHashtag';
 import SearchUser from 'pages/Search/SearchUser/SearchUser';
 import NotFound from 'pages/NotFound/NotFound';
 import PrivateRoute from 'PrivateRoute';
-import MissionMap from 'pages/BreakingMisson/MissionMap/MissionMap';
+import MissionMap from 'pages/BreakingMission/MissionMap/MissionMap';
 
 function App() {
   const queryClient = new QueryClient({

--- a/breaking-front/src/App.js
+++ b/breaking-front/src/App.js
@@ -26,6 +26,7 @@ import SearchHashtag from 'pages/Search/SearchHashtag/SearchHashtag';
 import SearchUser from 'pages/Search/SearchUser/SearchUser';
 import NotFound from 'pages/NotFound/NotFound';
 import PrivateRoute from 'PrivateRoute';
+import MissionMap from 'pages/BreakingMisson/MissionMap/MissionMap';
 
 function App() {
   const queryClient = new QueryClient({
@@ -95,7 +96,10 @@ function App() {
                     />
                     <Route path={PAGE_PATH.FINANCIAL} element={<Financial />} />
                   </Route>
-
+                  <Route
+                    path={PAGE_PATH.BREAKING_MISSION_MAP}
+                    element={<MissionMap />}
+                  />
                   <Route path="*" element={<NotFound />} />
                 </Routes>
               </Layout>

--- a/breaking-front/src/constants/path.js
+++ b/breaking-front/src/constants/path.js
@@ -14,7 +14,7 @@ export const PAGE_PATH = {
   SEARCH_POST: `/search/post`,
   SEARCH_HASHTAG: `/search/hashtag`,
   SEARCH_USER: `/search/user`,
-  BREAKING_MISSION_MAP: 'breaking_mission/map',
+  BREAKING_MISSION_MAP: 'breaking-mission/map',
   ERROR: `/not_found`,
 };
 

--- a/breaking-front/src/constants/path.js
+++ b/breaking-front/src/constants/path.js
@@ -14,6 +14,7 @@ export const PAGE_PATH = {
   SEARCH_POST: `/search/post`,
   SEARCH_HASHTAG: `/search/hashtag`,
   SEARCH_USER: `/search/user`,
+  BREAKING_MISSION_MAP: 'breaking_mission/map',
   ERROR: `/not_found`,
 };
 

--- a/breaking-front/src/mocks/dummyData/mission.js
+++ b/breaking-front/src/mocks/dummyData/mission.js
@@ -1,4 +1,4 @@
-export const mapList = [
+export const mapDummyInformation = [
   {
     missionId: 1,
     latitude: 37.57026135470516,

--- a/breaking-front/src/mocks/dummyData/mission.js
+++ b/breaking-front/src/mocks/dummyData/mission.js
@@ -1,0 +1,32 @@
+export const mapList = [
+  {
+    missionId: 1,
+    latitude: 37.57026135470516,
+    longitude: 126.92378529366763,
+  },
+  {
+    missionId: 2,
+    latitude: 37.280221721596156,
+    longitude: 127.52450100137139,
+  },
+  {
+    missionId: 3,
+    latitude: 37.44136688436345,
+    longitude: 127.27828806923868,
+  },
+  {
+    missionId: 4,
+    latitude: 37.58652596366754,
+    longitude: 126.97492168266787,
+  },
+  {
+    missionId: 5,
+    latitude: 37.55453653562958,
+    longitude: 126.99981609553,
+  },
+  {
+    missionId: 6,
+    latitude: 37.55518388656961,
+    longitude: 126.92926237742505,
+  },
+];

--- a/breaking-front/src/pages/BreakingMission/MissionMap/MissionMap.js
+++ b/breaking-front/src/pages/BreakingMission/MissionMap/MissionMap.js
@@ -19,7 +19,7 @@ const MissionMap = () => {
         borderRadius: '0px 0px 10px 10px',
         overflow: 'auto',
       }}
-      level={13} // 지도의 확대 레벨
+      level={12} // 지도의 확대 레벨
     >
       <MarkerClusterer averageCenter={true} minLevel={8}>
         {mapDummyInformation.map((mapInformation) => (

--- a/breaking-front/src/pages/BreakingMission/MissionMap/MissionMap.js
+++ b/breaking-front/src/pages/BreakingMission/MissionMap/MissionMap.js
@@ -1,7 +1,7 @@
 import { mapDummyInformation } from 'mocks/dummyData/mission';
 import React, { useState } from 'react';
 import { Map, MarkerClusterer } from 'react-kakao-maps-sdk';
-import MissionMapMarker from './components/MissionMapMarker';
+import MissionMapMarker from 'pages/BreakingMission/MissionMap/components/MissionMapMarker';
 
 const MissionMap = () => {
   const [selectedMissionId, setSelectedMissionId] = useState(1);

--- a/breaking-front/src/pages/BreakingMission/MissionMap/MissionMap.js
+++ b/breaking-front/src/pages/BreakingMission/MissionMap/MissionMap.js
@@ -1,0 +1,38 @@
+import { mapDummyInformation } from 'mocks/dummyData/mission';
+import React, { useState } from 'react';
+import { Map, MarkerClusterer } from 'react-kakao-maps-sdk';
+import MissionMapMarker from './components/MissionMapMarker';
+
+const MissionMap = () => {
+  const [selectedMissionId, setSelectedMissionId] = useState(1);
+
+  return (
+    <Map
+      center={{
+        lat: 36.2683,
+        lng: 127.6358,
+      }}
+      isPanto={true}
+      style={{
+        width: '100%',
+        height: `calc(100vh - 65px)`,
+        borderRadius: '0px 0px 10px 10px',
+        overflow: 'auto',
+      }}
+      level={13} // 지도의 확대 레벨
+    >
+      <MarkerClusterer averageCenter={true} minLevel={8}>
+        {mapDummyInformation.map((mapInformation) => (
+          <MissionMapMarker
+            key={mapInformation.missionId}
+            mapInformation={mapInformation}
+            selectedMissionId={selectedMissionId}
+            setSelectedMissionId={setSelectedMissionId}
+          />
+        ))}
+      </MarkerClusterer>
+    </Map>
+  );
+};
+
+export default MissionMap;

--- a/breaking-front/src/pages/BreakingMission/MissionMap/components/MissionMapMarker.js
+++ b/breaking-front/src/pages/BreakingMission/MissionMap/components/MissionMapMarker.js
@@ -1,0 +1,42 @@
+import { CustomOverlayMap, MapMarker } from 'react-kakao-maps-sdk';
+import React from 'react';
+import PropTypes from 'prop-types';
+import * as Style from 'pages/BreakingMission/MissionMap/components/MissionMapMarker.styles';
+
+const MissionMapMarker = ({
+  mapInformation,
+  selectedMissionId,
+  setSelectedMissionId,
+}) => {
+  return (
+    <>
+      <MapMarker
+        position={{
+          lat: mapInformation.latitude,
+          lng: mapInformation.longitude,
+        }}
+        clickable={true}
+        onClick={() => setSelectedMissionId(mapInformation.missionId)}
+      />
+      {selectedMissionId === mapInformation.missionId && (
+        <CustomOverlayMap
+          position={{
+            lat: mapInformation.latitude,
+            lng: mapInformation.longitude,
+          }}
+          yAnchor="2.6"
+        >
+          <Style.FeedUI>대충 내용</Style.FeedUI>
+        </CustomOverlayMap>
+      )}
+    </>
+  );
+};
+
+MissionMapMarker.propTypes = {
+  mapInformation: PropTypes.object,
+  setSelectedMissionId: PropTypes.func,
+  selectedMissionId: PropTypes.number,
+};
+
+export default MissionMapMarker;

--- a/breaking-front/src/pages/BreakingMission/MissionMap/components/MissionMapMarker.styles.js
+++ b/breaking-front/src/pages/BreakingMission/MissionMap/components/MissionMapMarker.styles.js
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const FeedUI = styled.div`
+  padding: 5px;
+  border: solid 2px ${({ theme }) => theme.gray[500]};
+  border-radius: 10px;
+  background-color: ${({ theme }) => theme.white};
+  font-size: 12px;
+`;


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #244 

## 예상 리뷰 시간
10-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
클러스터를 사용하여 UI를 구성하였습니다.

breakingMission folder를 만들어서 앞으로 하는 관련 작업들을 넣을 생각입니다.
대략적인 구상으로는 지도를 띄우면 지금 페이지로 이동하고 마커를 누르면 피드가 나오고 피드를 누르면 세부페이지로 이동하는 형식으로 구현할 생각입니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/49224104/188434332-348190ce-a3d8-4068-b84c-9c2b12094cc9.png)

![image](https://user-images.githubusercontent.com/49224104/188434534-b96f2679-a4e6-4d4a-bb74-c4c6bbd4a6cb.png)



## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
mission feed UI 작업이 끝나면 마커 위에 이를 띄울 생각입니다.

