### PR TITLE
refactor: ProfileSettingForm 컴포넌트 리팩토링

### DIFF
--- a/breaking-front/src/api/signUp.js
+++ b/breaking-front/src/api/signUp.js
@@ -11,11 +11,11 @@ export const postSignUp = (userData) => {
 };
 
 export const getProfileValidation = ({ queryKey }) => {
-  const [, query] = queryKey;
+  const [, { validType, profileData }] = queryKey;
 
   return api({
     method: 'get',
-    url: API_PATH.OAUTH2_SIGNUP_VALIDATE(query.validType, query.profileData),
+    url: API_PATH.OAUTH2_SIGNUP_VALIDATE(validType, profileData),
   });
 };
 

--- a/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.js
+++ b/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.js
@@ -14,12 +14,11 @@ import * as Style from 'components/ProfileSettingForm/ProfileSettingForm.styles'
 import { ReactComponent as XMark } from 'assets/svg/x_mark.svg';
 
 export default function ProfileSettingForm({
-  pageType,
-  username,
   isProfileDataLoading,
   isProfileMutateLoading,
   userDefaultData,
-  mutate,
+  onSubmit,
+  children,
 }) {
   const imageRef = useRef();
   const theme = useTheme();
@@ -42,21 +41,21 @@ export default function ProfileSettingForm({
   const [phoneNumberErrorMessage, setPhoneNumberErrorMessage] = useState('');
   const [emailErrorMessage, setEmailErrorMessage] = useState('');
 
-  const { refetch: NicknameReFetch } = useIsValidProfile(
-    'nickname',
-    nickname,
-    setNicknameErrorMessage
-  );
-  const { refetch: PhoneNumberReFetch } = useIsValidProfile(
-    'phone-number',
-    phoneNumber,
-    setPhoneNumberErrorMessage
-  );
-  const { refetch: EmailReFetch } = useIsValidProfile(
-    'email',
-    email,
-    setEmailErrorMessage
-  );
+  const { refetch: NicknameReFetch } = useIsValidProfile({
+    validType: 'nickname',
+    profileData: nickname,
+    setErrorMessage: setNicknameErrorMessage,
+  });
+  const { refetch: PhoneNumberReFetch } = useIsValidProfile({
+    validType: 'phone-number',
+    profileData: phoneNumber,
+    setErrorMessage: setPhoneNumberErrorMessage,
+  });
+  const { refetch: EmailReFetch } = useIsValidProfile({
+    validType: 'email',
+    profileData: email,
+    setErrorMessage: setEmailErrorMessage,
+  });
 
   const handleImageUploadPreview = (imageFile) => {
     if (!imageFile) return;
@@ -115,13 +114,11 @@ export default function ProfileSettingForm({
     event.preventDefault();
 
     if (nicknameErrorMessage)
-      return alert(MESSAGE.SIGNUP.SUBMIT_INVALID_NICKNAME);
+      return alert(MESSAGE.PROFILE_SETTING.SUBMIT_INVALID_NICKNAME);
     else if (phoneNumberErrorMessage)
-      return alert(MESSAGE.SIGNUP.SUBMIT_INVALID_PHONENUMBER);
+      return alert(MESSAGE.PROFILE_SETTING.SUBMIT_INVALID_PHONENUMBER);
     else if (emailErrorMessage)
-      return alert(MESSAGE.SIGNUP.SUBMIT_INVALID_EMAIL);
-
-    const formData = new FormData();
+      return alert(MESSAGE.PROFILE_SETTING.SUBMIT_INVALID_EMAIL);
 
     const userData = {
       realName,
@@ -132,30 +129,14 @@ export default function ProfileSettingForm({
       role,
     };
 
-    if (pageType === 'profileEdit') {
-      userData.isProfileImgChanged =
-        profileImg !== userDefaultData.profileImgURL;
-
-      formData.append(
-        'profileImg',
-        userData.isProfileImgChanged ? profileImg : null
-      );
-      formData.append('updateRequest', JSON.stringify(userData));
-    } else if (pageType === 'signUp') {
-      userData.username = username;
-
-      formData.append('profileImg', profileImg);
-      formData.append('signUpRequest', JSON.stringify(userData));
-    }
-
-    mutate(formData);
+    onSubmit({ userData, profileImg });
   };
 
   useEffect(() => {
     setForm(userDefaultData);
     userDefaultData.profileImgURL &&
       setImageSrc(ImageUrlConverter(userDefaultData.profileImgURL));
-  }, [userDefaultData, pageType, setForm]);
+  }, [userDefaultData, setForm]);
 
   return (
     <>
@@ -206,10 +187,9 @@ export default function ProfileSettingForm({
           onChange={handleChange}
           onBlur={() => {
             realName === ''
-              ? setRealNameErrorMessage(MESSAGE.SIGNUP.BLANK)
+              ? setRealNameErrorMessage(MESSAGE.PROFILE_SETTING.BLANK)
               : setRealNameErrorMessage('');
           }}
-          autoFocus
           required
         />
         <ProfileSettingInput
@@ -222,7 +202,7 @@ export default function ProfileSettingForm({
           onChange={handleChange}
           onBlur={() => {
             nickname === ''
-              ? setNicknameErrorMessage(MESSAGE.SIGNUP.BLANK)
+              ? setNicknameErrorMessage(MESSAGE.PROFILE_SETTING.BLANK)
               : NicknameReFetch();
           }}
           required
@@ -238,7 +218,7 @@ export default function ProfileSettingForm({
           maxLength="11"
           onBlur={() => {
             phoneNumber === ''
-              ? setPhoneNumberErrorMessage(MESSAGE.SIGNUP.BLANK)
+              ? setPhoneNumberErrorMessage(MESSAGE.PROFILE_SETTING.BLANK)
               : PhoneNumberReFetch();
           }}
           required
@@ -253,7 +233,7 @@ export default function ProfileSettingForm({
           onChange={handleChange}
           onBlur={() => {
             email === ''
-              ? setEmailErrorMessage(MESSAGE.SIGNUP.BLANK)
+              ? setEmailErrorMessage(MESSAGE.PROFILE_SETTING.BLANK)
               : EmailReFetch();
           }}
           required
@@ -292,7 +272,7 @@ export default function ProfileSettingForm({
           <Style.Loading type="bars" color={theme.blue[900]} />
         ) : (
           <Style.SubmitButton type="submit" size="large">
-            {pageType === 'signUp' ? '회원가입' : '프로필 수정'}
+            {children}
           </Style.SubmitButton>
         )}
       </Style.Form>
@@ -301,12 +281,11 @@ export default function ProfileSettingForm({
 }
 
 ProfileSettingForm.propTypes = {
-  pageType: PropTypes.oneOf(['signUp', 'profileEdit']).isRequired,
-  username: PropTypes.string,
   userDefaultData: PropTypes.object,
-  mutate: PropTypes.func.isRequired,
   isProfileDataLoading: PropTypes.bool,
   isProfileMutateLoading: PropTypes.bool,
+  onSubmit: PropTypes.func,
+  children: PropTypes.node,
 };
 
 ProfileSettingForm.defaultProps = {
@@ -320,5 +299,4 @@ ProfileSettingForm.defaultProps = {
     role: 'USER',
   },
   isProfileDataLoading: false,
-  isProfileMutateLoading: false,
 };

--- a/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.js
+++ b/breaking-front/src/components/ProfileSettingForm/ProfileSettingForm.js
@@ -41,21 +41,24 @@ export default function ProfileSettingForm({
   const [phoneNumberErrorMessage, setPhoneNumberErrorMessage] = useState('');
   const [emailErrorMessage, setEmailErrorMessage] = useState('');
 
-  const { refetch: NicknameReFetch } = useIsValidProfile({
-    validType: 'nickname',
-    profileData: nickname,
-    setErrorMessage: setNicknameErrorMessage,
-  });
-  const { refetch: PhoneNumberReFetch } = useIsValidProfile({
-    validType: 'phone-number',
-    profileData: phoneNumber,
-    setErrorMessage: setPhoneNumberErrorMessage,
-  });
-  const { refetch: EmailReFetch } = useIsValidProfile({
-    validType: 'email',
-    profileData: email,
-    setErrorMessage: setEmailErrorMessage,
-  });
+  const { isSuccess: isNicknameSuccess, refetch: NicknameReFetch } =
+    useIsValidProfile({
+      validType: 'nickname',
+      profileData: nickname,
+      setErrorMessage: setNicknameErrorMessage,
+    });
+  const { isSuccess: isPhoneNumberSuccess, refetch: PhoneNumberReFetch } =
+    useIsValidProfile({
+      validType: 'phone-number',
+      profileData: phoneNumber,
+      setErrorMessage: setPhoneNumberErrorMessage,
+    });
+  const { isSuccess: isEmailSuccess, refetch: EmailReFetch } =
+    useIsValidProfile({
+      validType: 'email',
+      profileData: email,
+      setErrorMessage: setEmailErrorMessage,
+    });
 
   const handleImageUploadPreview = (imageFile) => {
     if (!imageFile) return;
@@ -197,6 +200,7 @@ export default function ProfileSettingForm({
           name="nickname"
           placeholder="닉네임"
           label="닉네임"
+          isSuccess={isNicknameSuccess}
           errorMessage={nicknameErrorMessage}
           value={nickname}
           onChange={handleChange}
@@ -212,6 +216,7 @@ export default function ProfileSettingForm({
           name="phoneNumber"
           placeholder="전화번호"
           label="전화번호"
+          isSuccess={isPhoneNumberSuccess}
           errorMessage={phoneNumberErrorMessage}
           value={phoneNumber}
           onChange={handlePhoneNumberChange}
@@ -228,6 +233,7 @@ export default function ProfileSettingForm({
           name="email"
           label="이메일"
           placeholder="이메일"
+          isSuccess={isEmailSuccess}
           errorMessage={emailErrorMessage}
           value={email}
           onChange={handleChange}

--- a/breaking-front/src/components/ProfileSettingForm/ProfileSettingInput.js
+++ b/breaking-front/src/components/ProfileSettingForm/ProfileSettingInput.js
@@ -3,11 +3,16 @@ import PropTypes from 'prop-types';
 import * as Style from 'components/ProfileSettingForm/ProfileSettingInput.styles';
 
 const ProfileSettingInput = forwardRef(
-  ({ label, errorMessage, ...props }, ref) => {
+  ({ label, isSuccess, errorMessage, ...props }, ref) => {
     return (
       <Style.Label>
         <Style.LabelText>{label}</Style.LabelText>
-        <Style.ProfileSettingInput ref={ref} {...props} />
+        <Style.ProfileSettingInput
+          ref={ref}
+          isSuccess={isSuccess}
+          isError={!!errorMessage}
+          {...props}
+        />
         {errorMessage && <Style.Message>{errorMessage}</Style.Message>}
       </Style.Label>
     );
@@ -16,6 +21,7 @@ const ProfileSettingInput = forwardRef(
 
 ProfileSettingInput.propTypes = {
   label: PropTypes.string.isRequired,
+  isSuccess: PropTypes.bool,
   errorMessage: PropTypes.string,
 };
 

--- a/breaking-front/src/components/ProfileSettingForm/ProfileSettingInput.styles.js
+++ b/breaking-front/src/components/ProfileSettingForm/ProfileSettingInput.styles.js
@@ -15,9 +15,13 @@ export const ProfileSettingInput = styled.input`
   height: 56px;
   margin-top: 15px;
   padding: 10px 15px;
-  border: none;
+  border: ${({ theme, isSuccess, isError }) =>
+    isSuccess
+      ? `2px solid ${theme.blue[900]}`
+      : isError
+      ? `2px solid ${theme.red[900]}`
+      : `1px solid ${theme.gray[500]}`};
   border-radius: 10px;
-  background-color: ${({ theme }) => theme.gray[200]};
   font-size: 12px;
   outline: none;
 `;

--- a/breaking-front/src/constants/message.js
+++ b/breaking-front/src/constants/message.js
@@ -1,5 +1,5 @@
 const MESSAGE = {
-  SIGNUP: {
+  PROFILE_SETTING: {
     BLANK: '필수로 입력해야합니다.',
     SUBMIT_INVALID_NICKNAME: '닉네임을 올바르게 기입해주시기 바랍니다.',
     SUBMIT_INVALID_PHONENUMBER: '전화번호를 올바르게 기입해주시기 바랍니다.',

--- a/breaking-front/src/hooks/queries/useIsValidProfile.js
+++ b/breaking-front/src/hooks/queries/useIsValidProfile.js
@@ -1,7 +1,7 @@
 import { getProfileValidation } from 'api/signUp';
 import { useQuery } from 'react-query';
 
-const useIsValidProfile = (validType, profileData, setErrorMessage) =>
+const useIsValidProfile = ({ validType, profileData, setErrorMessage }) =>
   useQuery(
     ['validProfileData', { validType, profileData }],
     getProfileValidation,

--- a/breaking-front/src/pages/Authentication/SignUp/SignUp.js
+++ b/breaking-front/src/pages/Authentication/SignUp/SignUp.js
@@ -13,6 +13,15 @@ const SignUp = () => {
 
   const { mutate: SignUpMutate, isLoading: isSignUpLoading } = useSignUp();
 
+  const handleSubmit = ({ userData, profileImg }) => {
+    const formData = new FormData();
+    userData.username = location.state.username;
+    formData.append('profileImg', profileImg);
+    formData.append('signUpRequest', JSON.stringify(userData));
+
+    SignUpMutate(formData);
+  };
+
   useEffect(() => {
     if (!location.state) {
       if (isLogin) navigate(PAGE_PATH.HOME);
@@ -27,11 +36,11 @@ const SignUp = () => {
     <>
       {location.state && (
         <ProfileSettingForm
-          pageType="signUp"
-          username={location.state.username}
+          onSubmit={handleSubmit}
           isProfileMutateLoading={isSignUpLoading}
-          mutate={SignUpMutate}
-        />
+        >
+          회원가입
+        </ProfileSettingForm>
       )}
     </>
   );

--- a/breaking-front/src/pages/Profile/ProfileEdit/ProfileEdit.js
+++ b/breaking-front/src/pages/Profile/ProfileEdit/ProfileEdit.js
@@ -29,6 +29,20 @@ const ProfileEdit = () => {
     setIsChecked((pre) => !pre);
   };
 
+  const handleProfileEditSubmit = ({ userData, profileImg }) => {
+    const formData = new FormData();
+    userData.isProfileImgChanged =
+      profileImg !== profileData?.data.profileImgURL;
+
+    formData.append(
+      'profileImg',
+      userData.isProfileImgChanged ? profileImg : null
+    );
+    formData.append('updateRequest', JSON.stringify(userData));
+
+    ProfileEditMutate(formData);
+  };
+
   const handleWithdrawalSubmit = (event) => {
     event.preventDefault();
     isChecked ? ProfileWithdrawal(userId) : alert('동의하지 않았습니다.');
@@ -37,12 +51,13 @@ const ProfileEdit = () => {
   return (
     <>
       <ProfileSettingForm
-        pageType="profileEdit"
+        onSubmit={handleProfileEditSubmit}
         userDefaultData={profileData?.data}
         isProfileDataLoading={isProfileDataLoading}
         isProfileMutateLoading={isProfileEditLoading}
-        mutate={ProfileEditMutate}
-      />
+      >
+        프로필 수정
+      </ProfileSettingForm>
       <Line width="600px" />
       <Style.ToggleContainer>
         <Style.WithdrawalToggle onClick={toggleModal}>


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #249 

## 예상 리뷰 시간
6-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
ProfileSettingForm 컴포넌트를 리팩토링했습니다.
컴포넌트에서 submit했었던 기존 로직에서 page 단에서 submit을 처리하는 로직으로 수정했습니다.

## 스크린샷
![image](https://user-images.githubusercontent.com/23312485/188885412-b39364b0-4db7-4fc9-a975-12fae93b73ae.png)

## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
사용자가 회원가입 또는 프로필 수정에서 중복 검사를 할 때 사용 불가능한 값이면 에러 메시지가 뜨지만, 사용 가능한 값이라면 에러메시지가 안뜨는 것 외에 확인할 방법이 없어 수정이 필요해보입니다.

ex)
사용 가능 값 - 초록색 체크 아이콘
사용 불가능 값 - 빨간색 X 아이콘

input 왼쪽에 이런 식으로 직관적으로 표현해주면 좋을 것 같아 의견을 묻고 싶습니다.