### PR TITLE
feat: input창에서 enter를 누를시에 다음 input창으로 이동

### DIFF
--- a/breaking-front/src/components/PostWriteCommonForm/PostWriteCommonForm.js
+++ b/breaking-front/src/components/PostWriteCommonForm/PostWriteCommonForm.js
@@ -28,6 +28,16 @@ const PostWriteCommonForm = ({ onChangeData, data, setData }) => {
     setIsShowPriceInput((pre) => !pre);
   };
 
+  const nextInputFocus = (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.target.blur();
+      const form = event.target.form;
+      const index = Array.prototype.indexOf.call(form, event.target);
+      form.elements[index + 1].focus();
+    }
+  };
+
   return (
     <>
       <Style.OccurTimeLayout>
@@ -51,6 +61,7 @@ const PostWriteCommonForm = ({ onChangeData, data, setData }) => {
           value={data.title}
           onChange={onChangeData}
           name="title"
+          onKeyDown={nextInputFocus}
         />
         <Style.ContextBodyTextArea
           placeholder="상황을 최대한 상세하게 기록해 주세요&#13;(상황, 시간, 사건 전개과정, 경과상태 등)&#13;&#10;최대 2000자"
@@ -104,12 +115,7 @@ const PostWriteCommonForm = ({ onChangeData, data, setData }) => {
           onChange={handlePrice}
           onBlur={toggleShowPriceInput}
           onFocus={toggleShowPriceInput}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter') {
-              event.preventDefault();
-              event.target.blur();
-            }
-          }}
+          onKeyDown={nextInputFocus}
         />
       </Style.PriceLayout>
 


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #256 

## 예상 리뷰 시간
1-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
게시글 작성시에 title에서 enter를 누를시에 submit이 되는 부분을 수정하였습니다


## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![45345345](https://user-images.githubusercontent.com/49224104/192540660-0734f398-ae8b-4a40-bab3-db42124aac6d.gif)


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
`const index = Array.prototype.indexOf.call(form, event.target);` 
방법이 form(event.target.form)부분 즉 from객체에서 event.target 즉 현재 input창의 indexof를 찾아 내는 것 입니다 array함수를 form에 call해서 indexOf를 사용할수 있도록 하는것 같습니다.
그러면 `form.indexOf(event.target);` 으로 쓰면 안되는거냐 할텐데 form은 array가 아닌 객체로 indexOf를 사용할수 없습니다
자세한건 js를 깊게 파봐야 하지만 일단은 이렇게 이해하고 있습니다.
