### PR TITLE
feat: 통합검색에서 상태 메세지가 없을시 팔로우버튼의 레이아웃이 안맞는 문제 해결

### DIFF
--- a/breaking-front/src/pages/Search/SearchUnified/components/UserCard/UserCard.styles.js
+++ b/breaking-front/src/pages/Search/SearchUnified/components/UserCard/UserCard.styles.js
@@ -21,6 +21,7 @@ export const UserName = styled.div`
 `;
 export const UserStatusMsg = styled.div`
   width: 100%;
+  height: 12px;
   font-size: 10px;
   color: ${({ theme }) => theme.gray[700]};
   white-space: nowrap;


### PR DESCRIPTION
## 관련 이슈
<!-- close #이슈번호 -->
close #247 

## 예상 리뷰 시간
0-min

## 추가 또는 변경사항
<!-- 구체적으로 작성 부탁드립니다. -->
card의 css에 height를 고정해줌으로써 레이아웃이 안맞는 문제를 해결했습니다.

## 스크린샷
<!-- 추가되거나 변경된 사항을 이미지로 남겨주세요. -->
![image](https://user-images.githubusercontent.com/49224104/193442138-c39c0aa7-6070-4cbf-928f-44629b49097e.png)


## 기타
<!-- 작업 중 있언던 것들을 자유롭게 작성합니다. -->
